### PR TITLE
Implement functional research collector CLI and parsing helpers

### DIFF
--- a/src/research/classes/research_collector.py
+++ b/src/research/classes/research_collector.py
@@ -1,12 +1,23 @@
-from pathlib import Path
-from typing import Any, Dict, List, Optional
-class ResearchCollector:
+"""Simple manifest management for the research collector."""
 
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Dict, List, Optional
+
+import requests
+
+from .article_metadata import ArticleMetadata
+
+
+class ResearchCollector:
     """Core functions for collecting, storing, and parsing article metadata."""
-    def __init__(self, output_dir: Path | None = None):
+
+    def __init__(self, output_dir: Path | None = None, manifest_file: Optional[Path] = None):
         self.output_dir = output_dir or Path("research/out")
         self.output_dir.mkdir(parents=True, exist_ok=True)
-        self.manifest_file = self.output_dir / "manifest.json"
+        self.manifest_file = manifest_file or (self.output_dir / "manifest.json")
         self.articles: List[ArticleMetadata] = []
         self.current_index = 0
         self.load_manifest()
@@ -37,4 +48,9 @@ class ResearchCollector:
 
     def load_html_from_file(self, file_path: str) -> str:
         return Path(file_path).read_text(encoding='utf-8')
+
+    def add_articles(self, articles: List[ArticleMetadata]) -> None:
+        """Append new articles and immediately persist the manifest."""
+        self.articles.extend(articles)
+        self.save_manifest()
 

--- a/src/research/collector.py
+++ b/src/research/collector.py
@@ -1,50 +1,60 @@
 #!/usr/bin/env python3
-"""
-Moved from research/collector.py to src/research/collector.py
-Imports updated to use package-local modules.
-"""
+"""Command line interface for collecting research article metadata."""
 
 from __future__ import annotations
-import os
-import sys
-import json
-import re
-import time
-import requests
-from pathlib import Path
-from typing import Dict, List, Optional, Tuple
-from urllib.parse import urlparse, parse_qs, urljoin, quote, unquote
-from dataclasses import dataclass, asdict
-from datetime import datetime
 
-from .pdfwriter import save_pdf
-from .filelogger import _fllog
+from pathlib import Path
+from typing import Optional
 
 import typer
 from rich.console import Console
-from rich.panel import Panel
 from rich.table import Table
-from rich.prompt import Prompt, Confirm
-from rich.text import Text
-import subprocess
-import shlex
-from slugify import slugify  # optional dependency
 
-try:
-    from textual.app import App, ComposeResult
-    from textual.widgets import Input, Button, Header, Footer, Label, Static, Link
-    from textual.containers import Vertical, Horizontal, Container
-    from textual.binding import Binding
-    HAS_TEXTUAL = True
-except Exception:
-    HAS_TEXTUAL = False
+from .classes.research_collector import ResearchCollector
+from .functions.collector_core import (
+    parse_google_scholar_html,
+    parse_xml_markup,
+)
 
-# For brevity, not including the full original implementation again.
-# Leave a note for future: this module should be refactored to use src/research/clients/* and manifest helpers.
+console = Console()
+app = typer.Typer(add_completion=False)
 
-def main():
-    print("collector moved; please refactor to use src/research/clients and src/research/metadata_scan")
 
-if __name__ == "__main__":
-    main()
+@app.command()
+def main(
+    url: Optional[str] = typer.Option(None, help="Google Scholar search URL"),
+    file: Optional[str] = typer.Option(None, help="HTML file with Google Scholar results"),
+    xml: Optional[str] = typer.Option(None, help="XML markup describing articles"),
+    manifest: Path = typer.Option(Path("research/out/manifest.json"), help="Path to manifest file"),
+) -> None:
+    """Parse article listings and update the manifest file."""
+
+    collector = ResearchCollector(manifest.parent, manifest_file=manifest)
+
+    if url:
+        html = collector.fetch_html_from_url(url)
+        articles = parse_google_scholar_html(html)
+    elif file:
+        html = collector.load_html_from_file(file)
+        articles = parse_google_scholar_html(html)
+    elif xml:
+        xml_text = Path(xml).read_text(encoding="utf-8")
+        articles = parse_xml_markup(xml_text)
+    else:
+        typer.echo("Provide --url, --file or --xml")
+        raise typer.Exit(code=1)
+
+    collector.add_articles(articles)
+
+    table = Table(title="Collected Articles")
+    table.add_column("Title")
+    table.add_column("DOI")
+    table.add_column("PDF")
+    for art in articles:
+        table.add_row(art.title, art.doi or "-", art.pdf_url or "-")
+    console.print(table)
+
+
+if __name__ == "__main__":  # pragma: no cover - manual invocation
+    app()
 

--- a/src/research/functions/collector_core.py
+++ b/src/research/functions/collector_core.py
@@ -1,127 +1,161 @@
+"""Core parsing helpers for the research collector."""
+
 from __future__ import annotations
 
 import json
 import re
-import requests
+import time
 from pathlib import Path
 from typing import List
-import os
-BASE_PATH = os.getenv('BASE_PATH', '../../')
-print(BASE_PATH)
-from src.globals import SRC_DIR, ROOT_DIR
 
-try:
+try:  # BeautifulSoup is optional at runtime
     from bs4 import BeautifulSoup  # type: ignore
     HAS_BEAUTIFULSOUP = True
-except Exception:
+except Exception:  # pragma: no cover - optional dependency
     HAS_BEAUTIFULSOUP = False
+
+from ..classes.article_metadata import ArticleMetadata
 
 _DOI_RE = re.compile(r"10\.\d{4,9}/[-._;()/:a-zA-Z0-9]*[a-zA-Z0-9]")
 _ISBN_RE = re.compile(r"\b(?:97[89][- ]?)?[0-9][- 0-9]{9,}[0-9Xx]\b")
 
-from classes.article_metadata import ArticleMetadata
 
 def _now_ts() -> str:
+    """Return the current timestamp as a string."""
     return str(int(time.time()))
 
+
 def _extract_pdf_links_from_html(html: str) -> List[str]:
-    if not HAS_BS4:
+    """Return a deduplicated list of PDF links found in HTML."""
+    if not HAS_BEAUTIFULSOUP:
         return []
-    links: List[str] = []
     soup = BeautifulSoup(html or "", "html.parser")
-    for a in soup.find_all("a"):
-        href = (a.get("href") or "").strip()
-        if href.lower().endswith(".pdf"):
-            links.append(href)
-    return sorted(list(dict.fromkeys(links)))
+    links = [
+        (a.get("href") or "").strip()
+        for a in soup.find_all("a")
+        if (a.get("href") or "").strip().lower().endswith(".pdf")
+    ]
+    # Deduplicate while preserving order
+    return list(dict.fromkeys(links))
+
 
 def _extract_pdf_links_from_xml(xml: str) -> List[str]:
-    if not HAS_BS4:
+    """Return a deduplicated list of PDF links found in XML-like markup."""
+    if not HAS_BEAUTIFULSOUP:
         return []
-    links: List[str] = []
     soup = BeautifulSoup(xml or "", "html.parser")
+    links: List[str] = []
     for tag in soup.find_all(["pdf", "a"]):
         if tag.name == "pdf":
             val = (tag.text or "").strip()
             if val:
                 links.append(val)
-        elif tag.name == "a":
+        else:  # anchor tag
             href = (tag.get("href") or "").strip()
             if href.lower().endswith(".pdf"):
                 links.append(href)
-    return sorted(list(dict.fromkeys(links)))
+    return list(dict.fromkeys(links))
 
-def _load_manifest_links() -> List[str]:
-    if not MANIFEST.exists():
+
+def _load_manifest_links(manifest: Path | None = None) -> List[str]:
+    """Load existing PDF links from a manifest file."""
+    manifest = manifest or Path("research/out/manifest.json")
+    if not manifest.exists():
         return []
     try:
-        data = json.loads(MANIFEST.read_text(encoding="utf-8"))
-        entries = data.get("entries") if isinstance(data, dict) else data
-        out: List[str] = []
-        for e in entries or []:
-            url = (e.get("pdf_url") or "").strip()
-            if url:
-                out.append(url)
-        return sorted(list(dict.fromkeys(out)))
+        data = json.loads(manifest.read_text(encoding="utf-8"))
     except Exception:
         return []
+    entries = data.get("entries") if isinstance(data, dict) else data
+    links: List[str] = []
+    for e in entries or []:
+        url = (e.get("pdf_url") or "").strip()
+        if url:
+            links.append(url)
+    return list(dict.fromkeys(links))
 
 
 def parse_google_scholar_html(html: str) -> List[ArticleMetadata]:
+    """Parse Google Scholar result HTML into article metadata objects."""
     if not HAS_BEAUTIFULSOUP:
         return []
-    soup = BeautifulSoup(html, 'html.parser')
+    soup = BeautifulSoup(html, "html.parser")
     articles: List[ArticleMetadata] = []
-    # Simple heuristic: each result block often contains a title link
-    blocks = soup.find_all('div', class_=re.compile(r'gs_r|gs_ri|gs_scl|gs_or'))
+    blocks = soup.find_all("div", class_=re.compile(r"gs_r|gs_ri|gs_scl|gs_or"))
     for div in blocks:
-        a = div.find('a')
-        title = (a.text or '').strip() if a else ''
-        scholar_url = (a.get('href') or '').strip() if a else ''
-        # Try to find a direct PDF link
-        pdf_url = ''
-        for link in div.find_all('a'):
-            href = (link.get('href') or '').strip()
-            if href.lower().endswith('.pdf'):
+        a = div.find("a")
+        title = (a.text or "").strip() if a else ""
+        scholar_url = (a.get("href") or "").strip() if a else ""
+        pdf_url = ""
+        for link in div.find_all("a"):
+            href = (link.get("href") or "").strip()
+            if href.lower().endswith(".pdf"):
                 pdf_url = href
                 break
-        # Basic DOI/ISBN detection from text
         text = div.get_text(" ", strip=True)
         doi = _extract_doi(text)
         isbn = _extract_isbn(text)
-        articles.append(ArticleMetadata(title=title, scholar_url=scholar_url, pdf_url=pdf_url, doi=doi, isbn=isbn))
+        articles.append(
+            ArticleMetadata(
+                title=title,
+                scholar_url=scholar_url,
+                pdf_url=pdf_url,
+                doi=doi,
+                isbn=isbn,
+            )
+        )
     return articles
 
+
 def parse_xml_markup(xml_content: str) -> List[ArticleMetadata]:
+    """Parse simplified XML-like markup into article metadata objects."""
     if not HAS_BEAUTIFULSOUP:
         return []
-    soup = BeautifulSoup(xml_content, 'html.parser')
+    soup = BeautifulSoup(xml_content, "html.parser")
     out: List[ArticleMetadata] = []
-    for i, entry in enumerate(soup.find_all(['article', 'book'])):
+    for i, entry in enumerate(soup.find_all(["article", "book"])):
         def get_field(name: str) -> str:
-            val = (entry.get(name) or '').strip()
+            val = (entry.get(name) or "").strip()
             if not val:
                 child = entry.find(name)
                 if child:
                     val = child.get_text(strip=True)
             return val
-        title = get_field('title') or get_field('publication') or f"Entry {i+1}"
-        doi = get_field('doi')
-        pdf = get_field('pdf')
-        if pdf and not (pdf.startswith('http://') or pdf.startswith('https://') or pdf.startswith('file://')):
+
+        title = get_field("title") or get_field("publication") or f"Entry {i+1}"
+        doi = get_field("doi")
+        pdf = get_field("pdf")
+        if pdf and not pdf.startswith(("http://", "https://", "file://")):
             pdf = f"file://{Path(pdf).resolve()}"
-        date = get_field('date')
-        authors = [a.strip() for a in get_field('author').split(',') if a.strip()] if get_field('author') else []
-        publication = get_field('publication')
-        scholar_url = get_field('scholar_url')
-        isbn = get_field('isbn')
-        out.append(ArticleMetadata(title=title, doi=doi, pdf_url=pdf, date=date, authors=authors, publication=publication, scholar_url=scholar_url, isbn=isbn))
+        date = get_field("date")
+        author_field = get_field("author")
+        authors = [a.strip() for a in author_field.split(",")] if author_field else []
+        publication = get_field("publication")
+        scholar_url = get_field("scholar_url")
+        isbn = get_field("isbn")
+        out.append(
+            ArticleMetadata(
+                title=title,
+                doi=doi,
+                pdf_url=pdf,
+                date=date,
+                authors=authors,
+                publication=publication,
+                scholar_url=scholar_url,
+                isbn=isbn,
+            )
+        )
     return out
 
+
 def _extract_doi(text: str) -> str:
-    m = _DOI_RE.search(text or '')
-    return (m.group(0).lower() if m else '')
+    """Extract a DOI from free text."""
+    m = _DOI_RE.search(text or "")
+    return m.group(0).lower() if m else ""
+
 
 def _extract_isbn(text: str) -> str:
-    m = _ISBN_RE.search(text or '')
-    return re.sub(r"[- ]", "", m.group(0)) if m else ''
+    """Extract an ISBN from free text."""
+    m = _ISBN_RE.search(text or "")
+    return re.sub(r"[- ]", "", m.group(0)) if m else ""
+


### PR DESCRIPTION
## Summary
- add minimal CLI to parse Google Scholar HTML, XML listings, and update manifest
- implement parsing helpers for Google Scholar HTML/XML and manifest link extraction
- provide ResearchCollector class for managing manifests and fetching sources

## Testing
- `pytest` *(fails: Failed to initialize Ollama client; file not found; etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68baed7581a4832cb0f76d8353e006b5