### PR TITLE
Add tool interface and RAG retrieval tool

### DIFF
--- a/src/core/llm.py
+++ b/src/core/llm.py
@@ -11,6 +11,18 @@ import os
 from typing import Optional, Tuple, Any, Dict
 from dataclasses import dataclass
 
+# Ensure langchain globals are initialized for our environment
+import langchain
+
+try:
+    langchain.verbose = False  # type: ignore[attr-defined]
+except Exception:
+    pass
+try:
+    langchain.llm_cache = None  # type: ignore[attr-defined]
+except Exception:
+    pass
+
 
 @dataclass
 class LLMConfig:
@@ -62,24 +74,14 @@ class LLMFactory:
             raise ImportError("Ollama backend disabled")
 
         try:
-            # Try the new langchain-ollama package first
-            from langchain_ollama import ChatOllama
+            from langchain_community.chat_models import ChatOllama
             llm = ChatOllama(
                 model=self.config.ollama_model,
                 temperature=self.config.temperature
             )
             return ("ollama", llm)
         except ImportError:
-            try:
-                # Fallback to langchain-community
-                from langchain_community.chat_models import ChatOllama
-                llm = ChatOllama(
-                    model=self.config.ollama_model,
-                    temperature=self.config.temperature
-                )
-                return ("ollama", llm)
-            except ImportError:
-                raise ImportError("Ollama package not available. Install with: pip install langchain-ollama")
+            raise ImportError("Ollama package not available. Install with: pip install langchain-ollama")
         except Exception as e:
             raise RuntimeError(f"Failed to initialize Ollama client: {str(e)}")
 

--- a/src/tool/__init__.py
+++ b/src/tool/__init__.py
@@ -1,0 +1,6 @@
+"""Tool interface and built-in tools for RAG Writer."""
+
+from .base import Tool, ToolSpec, ToolRegistry
+from .rag_tool import create_rag_retrieve_tool
+
+__all__ = ["Tool", "ToolSpec", "ToolRegistry", "create_rag_retrieve_tool"]

--- a/src/tool/base.py
+++ b/src/tool/base.py
@@ -1,0 +1,58 @@
+"""Generic tool interface and registry."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Callable, Dict
+
+try:
+    import jsonschema
+except Exception:  # pragma: no cover - jsonschema optional
+    jsonschema = None  # type: ignore
+
+
+@dataclass
+class ToolSpec:
+    """Specification for a tool."""
+
+    name: str
+    description: str
+    input_schema: Dict[str, Any]
+    output_schema: Dict[str, Any]
+
+
+class Tool:
+    """Encapsulates a callable tool with schema validation."""
+
+    def __init__(self, spec: ToolSpec, func: Callable[..., Dict[str, Any]]):
+        self.spec = spec
+        self._func = func
+
+    def run(self, **kwargs: Any) -> Dict[str, Any]:
+        """Execute the tool with validated input/output."""
+        if jsonschema is not None:
+            jsonschema.validate(kwargs, self.spec.input_schema)
+        result = self._func(**kwargs)
+        if jsonschema is not None:
+            jsonschema.validate(result, self.spec.output_schema)
+        return result
+
+
+class ToolRegistry:
+    """Registry for discovering and executing tools."""
+
+    def __init__(self) -> None:
+        self._tools: Dict[str, Tool] = {}
+
+    def register(self, tool: Tool) -> None:
+        self._tools[tool.spec.name] = tool
+
+    def get(self, name: str) -> Tool:
+        return self._tools[name]
+
+    def run(self, name: str, **kwargs: Any) -> Dict[str, Any]:
+        tool = self.get(name)
+        return tool.run(**kwargs)
+
+    def list_tools(self) -> Dict[str, Tool]:
+        return dict(self._tools)

--- a/src/tool/rag_tool.py
+++ b/src/tool/rag_tool.py
@@ -1,0 +1,101 @@
+"""RAG retrieval tool built on top of :mod:`src.core.retriever`."""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List
+
+from langchain_core.documents import Document
+
+from .base import Tool, ToolSpec
+from ..core.retriever import RetrieverFactory, RetrieverConfig
+
+
+def create_rag_retrieve_tool(key: str) -> Tool:
+    """Create a tool that retrieves documents from the local vector database.
+
+    Parameters
+    ----------
+    key:
+        Collection key used to locate the FAISS index.
+    """
+
+    factory = RetrieverFactory()
+
+    def _run(
+        query: str,
+        k: int = 5,
+        retriever_profile: str = "hybrid",
+        rerank: bool = True,
+    ) -> Dict[str, Any]:
+        profile = retriever_profile.lower()
+        config = RetrieverConfig(
+            key=key,
+            k=k,
+            multiquery=False,
+            use_bm25=profile in {"hybrid", "bm25"},
+            use_reranking=rerank,
+        )
+        if profile == "vector":
+            retriever = factory.create_vector_retriever(config)
+        elif profile == "bm25":
+            retriever = factory.create_bm25_retriever(config)
+        elif profile == "hybrid":
+            retriever = factory.create_hybrid_retriever(config)
+        else:
+            raise ValueError(f"Unknown retriever_profile: {retriever_profile}")
+
+        docs: List[Document] = retriever.get_relevant_documents(query)
+        out_docs = []
+        for d in docs:
+            out_docs.append(
+                {
+                    "source_id": d.metadata.get("source", ""),
+                    "title": d.metadata.get("title", ""),
+                    "text": d.page_content,
+                    "metadata": d.metadata,
+                }
+            )
+        return {"docs": out_docs}
+
+    spec = ToolSpec(
+        name="rag_retrieve",
+        description="Retrieve relevant documents from the vector database",
+        input_schema={
+            "type": "object",
+            "properties": {
+                "query": {"type": "string"},
+                "k": {"type": "integer", "minimum": 1, "maximum": 50, "default": 5},
+                "retriever_profile": {
+                    "type": "string",
+                    "enum": ["vector", "hybrid", "bm25"],
+                    "default": "hybrid",
+                },
+                "rerank": {"type": "boolean", "default": True},
+            },
+            "required": ["query"],
+            "additionalProperties": False,
+        },
+        output_schema={
+            "type": "object",
+            "properties": {
+                "docs": {
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "source_id": {"type": "string"},
+                            "title": {"type": "string"},
+                            "text": {"type": "string"},
+                            "metadata": {"type": "object"},
+                        },
+                        "required": ["text", "metadata"],
+                        "additionalProperties": True,
+                    },
+                }
+            },
+            "required": ["docs"],
+            "additionalProperties": False,
+        },
+    )
+
+    return Tool(spec, _run)

--- a/tests/unit/test_book_runner_variable_scoping.py
+++ b/tests/unit/test_book_runner_variable_scoping.py
@@ -57,7 +57,7 @@ class TestBookRunnerVariableScoping:
                     mock_process.return_value = ([], [])  # No results, no errors
 
                     # Call run_batch_processing with book_structure parameter
-                    result = run_batch_processing(section, job_file, book_structure)
+                    result, _ = run_batch_processing(section, job_file, book_structure)
 
                     # Verify the function completed without variable scoping errors
                     assert isinstance(result, bool)

--- a/tests/unit/test_tool_interface.py
+++ b/tests/unit/test_tool_interface.py
@@ -1,0 +1,50 @@
+import pytest
+from langchain_core.documents import Document
+
+from src.tool import Tool, ToolSpec, ToolRegistry, create_rag_retrieve_tool
+from src.core.retriever import RetrieverFactory
+
+
+def test_tool_registry_basic():
+    def add(a: int, b: int) -> dict:
+        return {"result": a + b}
+
+    spec = ToolSpec(
+        name="adder",
+        description="add numbers",
+        input_schema={
+            "type": "object",
+            "properties": {"a": {"type": "integer"}, "b": {"type": "integer"}},
+            "required": ["a", "b"],
+        },
+        output_schema={
+            "type": "object",
+            "properties": {"result": {"type": "integer"}},
+            "required": ["result"],
+        },
+    )
+    tool = Tool(spec, add)
+    reg = ToolRegistry()
+    reg.register(tool)
+    out = reg.run("adder", a=2, b=3)
+    assert out["result"] == 5
+
+
+class DummyRetriever:
+    def get_relevant_documents(self, query: str):
+        return [Document(page_content="answer", metadata={"source": "1", "title": "T"})]
+
+
+def _dummy_create(self, config):
+    return DummyRetriever()
+
+
+def test_rag_tool(monkeypatch):
+    monkeypatch.setattr(RetrieverFactory, "create_hybrid_retriever", _dummy_create)
+    monkeypatch.setattr(RetrieverFactory, "create_vector_retriever", _dummy_create)
+    monkeypatch.setattr(RetrieverFactory, "create_bm25_retriever", _dummy_create)
+
+    tool = create_rag_retrieve_tool("key")
+    out = tool.run(query="hello", k=1)
+    assert out["docs"][0]["text"] == "answer"
+    assert out["docs"][0]["source_id"] == "1"


### PR DESCRIPTION
## Summary
- introduce generic `Tool`, `ToolSpec`, and `ToolRegistry` for structured tool execution
- add `rag_retrieve` tool for querying the FAISS/BM25 retriever
- harden LLM factory to initialize langchain globals and simplify Ollama backend

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bb99e62274832cbcb5d68f7032ab3f