### PR TITLE
Add simple LLM tool agent

### DIFF
--- a/src/tool/__init__.py
+++ b/src/tool/__init__.py
@@ -1,6 +1,13 @@
 """Tool interface and built-in tools for RAG Writer."""
 
 from .base import Tool, ToolSpec, ToolRegistry
+from .agent import run_agent
 from .rag_tool import create_rag_retrieve_tool
 
-__all__ = ["Tool", "ToolSpec", "ToolRegistry", "create_rag_retrieve_tool"]
+__all__ = [
+    "Tool",
+    "ToolSpec",
+    "ToolRegistry",
+    "run_agent",
+    "create_rag_retrieve_tool",
+]

--- a/src/tool/agent.py
+++ b/src/tool/agent.py
@@ -1,0 +1,78 @@
+"""Simple LLM-powered tool agent."""
+
+from __future__ import annotations
+
+import json
+from typing import Dict, List
+
+from .base import ToolRegistry
+
+
+def run_agent(
+    llm,
+    registry: ToolRegistry,
+    question: str,
+    max_iters: int = 5,
+) -> str:
+    """Run a simple agent loop until a final answer is produced.
+
+    Args:
+        llm: Callable LLM accepting a list of ``{"role", "content"}`` messages
+            and returning a string response.
+        registry: The ``ToolRegistry`` containing available tools.
+        question: Initial user question to kick off the conversation.
+        max_iters: Maximum number of LLM/tool iterations.
+
+    Returns:
+        Final answer string produced by the agent.
+
+    The LLM is expected to return JSON of the form:
+        ``{"tool": name, "args": {...}}`` to call a tool or
+        ``{"final": text}`` to terminate.
+
+    Minimal error handling is performed for invalid tool names
+    or malformed schemas: errors are appended to the conversation
+    allowing the LLM to recover.
+    """
+
+    messages: List[Dict[str, str]] = [{"role": "user", "content": question}]
+
+    for _ in range(max_iters):
+        # Call the LLM
+        if hasattr(llm, "invoke"):
+            response = llm.invoke(messages)  # type: ignore[attr-defined]
+        else:
+            response = llm(messages)  # type: ignore[call-arg]
+
+        if isinstance(response, dict) and "content" in response:
+            text = response["content"]
+        else:
+            text = str(response)
+
+        try:
+            data = json.loads(text)
+        except Exception:
+            raise ValueError("LLM did not return valid JSON")
+
+        if "final" in data:
+            return str(data["final"])
+        if "tool" not in data or "args" not in data:
+            raise ValueError("LLM output missing 'tool' or 'args'")
+
+        tool_name = str(data["tool"])
+        args = data.get("args", {})
+        if not isinstance(args, dict):
+            args = {}
+
+        try:
+            result = registry.run(tool_name, **args)
+        except KeyError:
+            result = {"error": f"Unknown tool: {tool_name}"}
+        except Exception as e:  # pragma: no cover - guardrail
+            result = {"error": f"Tool {tool_name} failed: {e}"}
+
+        # Append LLM tool call and tool result to conversation
+        messages.append({"role": "assistant", "content": text})
+        messages.append({"role": "user", "content": json.dumps(result)})
+
+    raise RuntimeError("Agent did not produce a final answer")

--- a/tests/unit/test_tool_interface.py
+++ b/tests/unit/test_tool_interface.py
@@ -1,7 +1,8 @@
+import json
 import pytest
 from langchain_core.documents import Document
 
-from src.tool import Tool, ToolSpec, ToolRegistry, create_rag_retrieve_tool
+from src.tool import Tool, ToolSpec, ToolRegistry, create_rag_retrieve_tool, run_agent
 from src.core.retriever import RetrieverFactory
 
 
@@ -57,3 +58,60 @@ def test_rag_tool(monkeypatch):
     out = tool.run(query="hello", k=1)
     assert out["docs"][0]["text"] == "answer"
     assert out["docs"][0]["source_id"] == "1"
+
+
+def test_run_agent_basic():
+    """Agent should call tool and return final answer."""
+
+    def add(a: int, b: int) -> dict:
+        return {"result": a + b}
+
+    spec = ToolSpec(
+        name="adder",
+        description="add numbers",
+        input_schema={
+            "type": "object",
+            "properties": {"a": {"type": "integer"}, "b": {"type": "integer"}},
+            "required": ["a", "b"],
+        },
+        output_schema={
+            "type": "object",
+            "properties": {"result": {"type": "integer"}},
+            "required": ["result"],
+        },
+    )
+    reg = ToolRegistry()
+    reg.register(Tool(spec, add))
+
+    class DummyLLM:
+        def __init__(self):
+            self.calls = 0
+
+        def __call__(self, messages):
+            if self.calls == 0:
+                self.calls += 1
+                return json.dumps({"tool": "adder", "args": {"a": 2, "b": 3}})
+            return json.dumps({"final": "5"})
+
+    answer = run_agent(DummyLLM(), reg, "what is 2+3?")
+    assert answer == "5"
+
+
+def test_run_agent_invalid_tool():
+    """Unknown tool names should surface an error message."""
+
+    reg = ToolRegistry()
+
+    class DummyLLM:
+        def __init__(self):
+            self.calls = 0
+
+        def __call__(self, messages):
+            if self.calls == 0:
+                self.calls += 1
+                return json.dumps({"tool": "missing", "args": {}})
+            # Second call should receive the error message and finalize
+            return json.dumps({"final": messages[-1]["content"]})
+
+    answer = run_agent(DummyLLM(), reg, "hello")
+    assert "Unknown tool" in answer


### PR DESCRIPTION
## Summary
- add `run_agent` helper that loops with an LLM, parses JSON, runs tools and returns a final answer
- expose the agent via `src.tool` package
- cover agent behavior with unit tests

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bcd52cc90c832cae180e6fe5542f5a