### PR TITLE
Add tool prompt template and JSON schema docs

### DIFF
--- a/docs/tool_agent_schema.md
+++ b/docs/tool_agent_schema.md
@@ -1,0 +1,31 @@
+# Tool Agent JSON Schema
+
+The tool agent communicates exclusively using JSON in one of two forms:
+
+## 1. Tool Invocation
+```json
+{
+  "tool": "<tool_name>",
+  "args": {
+    /* arguments matching the tool's input_schema */
+  }
+}
+```
+
+## 2. Final Response
+```json
+{
+  "final": "<answer text>"
+}
+```
+
+Any other output is considered invalid.
+
+## Example Transcript
+```text
+System: <prompt listing tools>
+User: "What is 2 + 2?"
+Assistant: {"tool": "calculator", "args": {"expression": "2+2"}}
+User: {"result": 4}
+Assistant: {"final": "2 + 2 = 4"}
+```

--- a/src/tool/prompts/__init__.py
+++ b/src/tool/prompts/__init__.py
@@ -1,0 +1,5 @@
+"""Prompt templates for tool-based agents."""
+
+from .tool_prompt import generate_tool_prompt
+
+__all__ = ["generate_tool_prompt"]

--- a/src/tool/prompts/tool_prompt.py
+++ b/src/tool/prompts/tool_prompt.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+import json
+from typing import List, Dict
+
+from ..base import ToolRegistry
+
+
+def generate_tool_prompt(registry: ToolRegistry) -> str:
+    """Generate a system prompt describing available tools.
+
+    The returned prompt lists each tool from ``registry.describe()`` and
+    instructs the model to respond **only** with JSON in one of two forms::
+
+        {"tool": "<name>", "args": {...}}
+        {"final": "<answer>"}
+    """
+
+    tools: List[Dict[str, object]] = registry.describe()
+    lines = ["You can use the following tools:"]
+    for tool in tools:
+        schema = json.dumps(tool.get("input_schema", {}), separators=(",", ":"))
+        lines.append(
+            f"- {tool['name']}: {tool['description']} | args schema: {schema}"
+        )
+
+    instructions = (
+        "\nRespond ONLY with JSON. To call a tool, respond with\n"
+        '{"tool": "<tool_name>", "args": {<tool arguments>}}\n'
+        "To provide the final answer, respond with\n"
+        '{"final": "<answer text>"}'
+    )
+    return "\n".join(lines) + "\n\n" + instructions + "\n"


### PR DESCRIPTION
## Summary
- add `generate_tool_prompt` utility to list tools and enforce JSON-only responses
- document expected tool-agent JSON schema with example transcript

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bcd6489254832c8c7e2125e10f6692