### PR TITLE
Escape JSON braces in tool prompt

### DIFF
--- a/src/tool/prompts/tool_prompt.py
+++ b/src/tool/prompts/tool_prompt.py
@@ -20,6 +20,7 @@ def generate_tool_prompt(registry: ToolRegistry) -> str:
     lines = ["You can use the following tools:"]
     for tool in tools:
         schema = json.dumps(tool.get("input_schema", {}), separators=(",", ":"))
+        schema = schema.replace("{", "{{").replace("}", "}}")
         lines.append(
             f"- {tool['name']}: {tool['description']} | args schema: {schema}"
         )
@@ -29,5 +30,5 @@ def generate_tool_prompt(registry: ToolRegistry) -> str:
         '{"tool": "<tool_name>", "args": {<tool arguments>}}\n'
         "To provide the final answer, respond with\n"
         '{"final": "<answer text>"}'
-    )
+    ).replace("{", "{{").replace("}", "}}")
     return "\n".join(lines) + "\n\n" + instructions + "\n"

--- a/tests/unit/test_tool_prompt.py
+++ b/tests/unit/test_tool_prompt.py
@@ -1,0 +1,40 @@
+import json
+
+from langchain_core.prompts import ChatPromptTemplate
+
+from src.tool import Tool, ToolSpec, ToolRegistry
+from src.tool.prompts.tool_prompt import generate_tool_prompt
+
+
+def test_generate_tool_prompt_works_with_chat_prompt_template():
+    def add(a: int, b: int) -> dict:
+        return {"result": a + b}
+
+    spec = ToolSpec(
+        name="adder",
+        description="add numbers",
+        input_schema={
+            "type": "object",
+            "properties": {
+                "a": {"type": "integer"},
+                "b": {"type": "integer"},
+            },
+            "required": ["a", "b"],
+        },
+        output_schema={
+            "type": "object",
+            "properties": {"result": {"type": "integer"}},
+            "required": ["result"],
+        },
+    )
+    registry = ToolRegistry()
+    registry.register(Tool(spec, add))
+
+    prompt_text = generate_tool_prompt(registry)
+    prompt = ChatPromptTemplate.from_messages([
+        ("system", prompt_text),
+        ("user", "{input}"),
+    ])
+
+    messages = prompt.format_messages(input="hello")
+    assert '{"tool": "<tool_name>"' in messages[0].content


### PR DESCRIPTION
## Summary
- escape JSON braces in tool prompt for ChatPromptTemplate compatibility
- add test verifying generate_tool_prompt works with ChatPromptTemplate

## Testing
- `pytest tests/unit/test_tool_prompt.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68bcebec4824832c90f891838c728662