### PR TITLE
Handle JSON parsing errors in agent loop

### DIFF
--- a/src/tool/agent.py
+++ b/src/tool/agent.py
@@ -51,8 +51,16 @@ def run_agent(
 
         try:
             data = json.loads(text)
-        except Exception:
-            raise ValueError("LLM did not return valid JSON")
+        except json.JSONDecodeError as e:
+            # Append error message and continue the loop
+            messages.append({"role": "assistant", "content": text})
+            messages.append(
+                {
+                    "role": "user",
+                    "content": json.dumps({"error": f"Invalid JSON: {e}"}),
+                }
+            )
+            continue
 
         if "final" in data:
             return str(data["final"])


### PR DESCRIPTION
## Summary
- Gracefully handle invalid JSON responses from the LLM by catching `JSONDecodeError`
- Append error messages to the conversation instead of raising immediately

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bcebe05f04832c8bfe0a2f5933e1a0