### PR TITLE
Handle missing tool or args in agent

### DIFF
--- a/src/tool/agent.py
+++ b/src/tool/agent.py
@@ -75,7 +75,16 @@ def run_agent(
         if "final" in data:
             return str(data["final"])
         if "tool" not in data or "args" not in data:
-            raise ValueError("LLM output missing 'tool' or 'args'")
+            messages.append({"role": "assistant", "content": text})
+            messages.append(
+                {
+                    "role": "user",
+                    "content": json.dumps(
+                        {"error": "LLM output missing 'tool' or 'args'"}
+                    ),
+                }
+            )
+            continue
 
         tool_name = str(data["tool"])
         args = data.get("args", {})

--- a/tests/unit/test_tool_agent.py
+++ b/tests/unit/test_tool_agent.py
@@ -44,3 +44,22 @@ def test_tool_agent_executes_tool_and_returns_final_answer():
 
     assert calls["tool"] == 1
     assert answer == "5"
+
+
+def test_tool_agent_handles_missing_tool_or_args():
+    """Agent should surface an error if "tool" or "args" are missing."""
+
+    reg = ToolRegistry()
+
+    class DummyLLM:
+        def __init__(self):
+            self.calls = 0
+
+        def __call__(self, messages):
+            if self.calls == 0:
+                self.calls += 1
+                return json.dumps({"foo": "bar"})
+            return json.dumps({"final": messages[-1]["content"]})
+
+    answer = run_agent(DummyLLM(), reg, "hello")
+    assert "LLM output missing 'tool' or 'args'" in answer


### PR DESCRIPTION
## Summary
- Avoid raising on missing tool or args; append structured error and retry.
- Add regression test for missing tool/args handling.

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bd029be4a0832c8e2ceafa182622af