### PR TITLE
Add MCP client helpers

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -45,3 +45,5 @@ langchain-openai>=0.1.7,<0.2
 langchain-huggingface>=0.0.3
 langchain-ollama>=0.1.0
 langchain-openai>=0.1.7
+
+mcp

--- a/src/tool/__init__.py
+++ b/src/tool/__init__.py
@@ -3,6 +3,7 @@
 from .base import Tool, ToolSpec, ToolRegistry
 from .agent import run_agent
 from .rag_tool import create_rag_retrieve_tool
+from .mcp_client import connect, fetch_tools, call_tool
 
 __all__ = [
     "Tool",
@@ -10,4 +11,7 @@ __all__ = [
     "ToolRegistry",
     "run_agent",
     "create_rag_retrieve_tool",
+    "connect",
+    "fetch_tools",
+    "call_tool",
 ]

--- a/src/tool/mcp_client.py
+++ b/src/tool/mcp_client.py
@@ -1,0 +1,72 @@
+"""Client helpers for interacting with MCP servers."""
+
+from __future__ import annotations
+
+from contextlib import asynccontextmanager
+from typing import Any, AsyncIterator, Dict
+
+from mcp import ClientSession
+from mcp.client import stdio
+
+from .base import ToolSpec
+
+
+@asynccontextmanager
+async def connect(server_url: str) -> AsyncIterator[ClientSession]:
+    """Establish an MCP session using a stdio server.
+
+    Parameters
+    ----------
+    server_url: str
+        Path to the server executable. Only stdio servers are currently
+        supported.
+
+    Yields
+    ------
+    ClientSession
+        An initialized MCP client session.
+    """
+    params = stdio.StdioServerParameters(command=server_url)
+    async with stdio.stdio_client(params) as (read_stream, write_stream):
+        session = ClientSession(read_stream, write_stream)
+        await session.initialize()
+        yield session
+
+
+async def fetch_tools(session: ClientSession) -> list[ToolSpec]:
+    """Fetch available tools from the MCP server.
+
+    Parameters
+    ----------
+    session: ClientSession
+        Active MCP session.
+
+    Returns
+    -------
+    list[ToolSpec]
+        Tool specifications advertised by the server.
+    """
+    result = await session.list_tools()
+    specs: list[ToolSpec] = []
+    for tool in result.tools:
+        specs.append(
+            ToolSpec(
+                name=tool.name,
+                description=tool.description or "",
+                input_schema=tool.inputSchema,
+                output_schema=tool.outputSchema or {"type": "object"},
+            )
+        )
+    return specs
+
+
+async def call_tool(
+    session: ClientSession, name: str, args: Dict[str, Any] | None = None
+) -> Dict[str, Any]:
+    """Invoke a tool on the MCP server and return its structured content."""
+    result = await session.call_tool(name, args or {})
+    if result.isError:
+        raise RuntimeError("Tool call returned an error")
+    if result.structuredContent is not None:
+        return result.structuredContent
+    return {"content": [block.model_dump() for block in result.content]}


### PR DESCRIPTION
## Summary
- add `mcp` dependency
- implement helper functions to connect to an MCP server, list tools, and invoke tools
- expose MCP client helpers from tool package

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bd3e7d04b4832ca80f1fa83f039e2f