### PR TITLE
feat: support MCP tools

### DIFF
--- a/src/tool/base.py
+++ b/src/tool/base.py
@@ -5,6 +5,11 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Any, Callable, Dict
 
+try:  # pragma: no cover - optional dependency
+    import mcp_client  # type: ignore
+except Exception:  # pragma: no cover - MCP optional
+    mcp_client = None  # type: ignore
+
 try:
     import jsonschema
 except Exception:  # pragma: no cover - jsonschema optional
@@ -43,6 +48,8 @@ class ToolRegistry:
 
     def __init__(self) -> None:
         self._tools: Dict[str, Tool] = {}
+        self._mcp_tools: Dict[str, ToolSpec] = {}
+        self._mcp_client: Any | None = None
 
     def register(self, tool: Tool) -> None:
         self._tools[tool.spec.name] = tool
@@ -50,9 +57,40 @@ class ToolRegistry:
     def get(self, name: str) -> Tool:
         return self._tools[name]
 
+    def register_mcp_server(self, server_url: str) -> None:
+        """Connect to an MCP server and register its tools."""
+
+        if mcp_client is None:  # pragma: no cover - MCP optional
+            raise RuntimeError("mcp_client dependency not available")
+
+        client = mcp_client.connect(server_url)
+        for t in client.fetch_tools():
+            spec = ToolSpec(
+                name=t["name"],
+                description=t.get("description", ""),
+                input_schema=t.get("input_schema", {}),
+                output_schema=t.get("output_schema", {}),
+            )
+            self._mcp_tools[spec.name] = spec
+        self._mcp_client = client
+
     def run(self, name: str, **kwargs: Any) -> Dict[str, Any]:
-        tool = self.get(name)
-        return tool.run(**kwargs)
+        if name in self._tools:
+            tool = self._tools[name]
+            return tool.run(**kwargs)
+
+        if name in self._mcp_tools:
+            spec = self._mcp_tools[name]
+            if jsonschema is not None:
+                jsonschema.validate(kwargs, spec.input_schema)
+            if self._mcp_client is None:  # pragma: no cover - register first
+                raise RuntimeError("MCP server not registered")
+            result = self._mcp_client.call_tool(name, **kwargs)
+            if jsonschema is not None:
+                jsonschema.validate(result, spec.output_schema)
+            return result
+
+        raise KeyError(name)
 
     def list_tools(self) -> Dict[str, Tool]:
         return dict(self._tools)
@@ -71,6 +109,14 @@ class ToolRegistry:
                     "name": tool.spec.name,
                     "description": tool.spec.description,
                     "input_schema": tool.spec.input_schema,
+                }
+            )
+        for spec in self._mcp_tools.values():
+            out.append(
+                {
+                    "name": spec.name,
+                    "description": spec.description,
+                    "input_schema": spec.input_schema,
                 }
             )
         return out


### PR DESCRIPTION
## Summary
- add `register_mcp_server` to load Model Context Protocol tools
- invoke MCP tools via `mcp_client.call_tool`
- test MCP tool registration and execution with mocked server

## Testing
- `pytest tests/unit/test_tool_interface.py::test_mcp_tool_registration_and_invocation -q`
- `pytest tests/unit/test_tool_interface.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68bd3e8211ec832c935de7e6d493beb6