### PR TITLE
feat: add MCP tool server

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -308,8 +308,8 @@ quality: format lint test
 ## Start unified tool shell for advanced operations
 tool-shell:
 	@k="$(KEY)"; \
-	if [ -n "$$k" ]; then RAG_KEY="$$k" $(PY) $(ROOT)/src/tool/cli.py shell; \
-	else $(PY) $(ROOT)/src/tool/cli.py shell; fi
+	if [ -n "$$k" ]; then RAG_KEY="$$k" $(PY) -m src.tool.mcp_server; \
+	else $(PY) -m src.tool.mcp_server; fi
 
 # ===== EXAMPLE WORKFLOWS =====
 

--- a/README.md
+++ b/README.md
@@ -1387,6 +1387,14 @@ or a final response:
 
 See [docs/tool_agent_schema.md](docs/tool_agent_schema.md) for the full specification and transcript example.
 
+### MCP Tool Server
+
+Start the tool server to expose registered tools via the Model Context Protocol:
+
+```bash
+python -m src.tool.mcp_server  # or: make tool-shell
+```
+
 ## 🔍 Troubleshooting
 
 ### Common Issues

--- a/src/tool/mcp_server.py
+++ b/src/tool/mcp_server.py
@@ -1,0 +1,77 @@
+"""Model Context Protocol server exposing tools from ``ToolRegistry``."""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List
+
+from .base import ToolRegistry
+
+try:  # pragma: no cover - optional dependency
+    from mcp.server import NotificationOptions, Server
+    from mcp.server.stdio import stdio_server
+    import mcp.types as types
+except Exception:  # pragma: no cover - library not installed
+    Server = None  # type: ignore
+    stdio_server = None  # type: ignore
+    types = None  # type: ignore
+
+
+def _as_mcp_tools(registry: ToolRegistry) -> List["types.Tool"]:
+    """Convert registry tools to MCP ``Tool`` objects."""
+    tools: List["types.Tool"] = []
+    for tool in registry.list_tools().values():
+        spec = tool.spec
+        tools.append(
+            types.Tool(
+                name=spec.name,
+                description=spec.description,
+                inputSchema=spec.input_schema,
+                outputSchema=spec.output_schema,
+            )
+        )
+    return tools
+
+
+def create_server(registry: ToolRegistry) -> "Server":
+    """Create an MCP ``Server`` wired to the ``ToolRegistry``."""
+    if Server is None or types is None:
+        raise RuntimeError("mcp library is required to run the tool server")
+
+    server = Server("rag-writer-tool")
+
+    @server.list_tools()
+    async def list_tools() -> List["types.Tool"]:
+        return _as_mcp_tools(registry)
+
+    @server.call_tool()
+    async def call_tool(name: str, arguments: Dict[str, Any] | None) -> Dict[str, Any]:
+        return registry.run(name, **(arguments or {}))
+
+    return server
+
+
+def serve(registry: ToolRegistry | None = None) -> None:
+    """Run the tool server using stdio transport."""
+    if Server is None or stdio_server is None or types is None:
+        raise RuntimeError("mcp library is required to run the tool server")
+
+    registry = registry or ToolRegistry()
+    server = create_server(registry)
+
+    async def _run() -> None:
+        async with stdio_server() as (read, write):
+            options = server.create_initialization_options(NotificationOptions())
+            await server.run(read, write, options)
+
+    import anyio
+
+    anyio.run(_run)
+
+
+def main() -> None:
+    """CLI entry point to start the MCP tool server."""
+    serve()
+
+
+if __name__ == "__main__":  # pragma: no cover
+    main()


### PR DESCRIPTION
## Summary
- expose registry tools via an MCP stdio server
- add `tool-shell` target to launch the server
- document server startup in README

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'langchain_core')*
- `python -m black src/tool/mcp_server.py`


------
https://chatgpt.com/codex/tasks/task_e_68bd3e86b34c832cafa191880d607829