### PR TITLE
feat: allow raw descriptors for tool prompt

### DIFF
--- a/src/tool/prompts/tool_prompt.py
+++ b/src/tool/prompts/tool_prompt.py
@@ -1,25 +1,36 @@
 from __future__ import annotations
 
 import json
-from typing import List, Dict
+from typing import Iterable, Mapping, Union, Any
 
 from ..base import ToolRegistry
 
 
-def generate_tool_prompt(registry: ToolRegistry) -> str:
+def generate_tool_prompt(
+    registry_or_tools: Union[ToolRegistry, Iterable[Mapping[str, Any]]]
+) -> str:
     """Generate a system prompt describing available tools.
 
-    The returned prompt lists each tool from ``registry.describe()`` and
-    instructs the model to respond **only** with JSON in one of two forms::
+    Accepts either a :class:`~src.tool.base.ToolRegistry` instance or an iterable
+    of tool descriptors such as the raw output from ``mcp_client.fetch_tools``.
+    The returned prompt lists each tool and instructs the model to respond
+    **only** with JSON in one of two forms::
 
         {"tool": "<name>", "args": {...}}
         {"final": "<answer>"}
     """
 
-    tools: List[Dict[str, object]] = registry.describe()
+    if isinstance(registry_or_tools, ToolRegistry):
+        tools = registry_or_tools.describe()
+    else:
+        tools = list(registry_or_tools)
+
     lines = ["You can use the following tools:"]
     for tool in tools:
-        schema = json.dumps(tool.get("input_schema", {}), separators=(",", ":"))
+        schema = json.dumps(
+            tool.get("input_schema") or tool.get("inputSchema") or {},
+            separators=(",", ":"),
+        )
         lines.append(
             f"- {tool['name']}: {tool['description']} | args schema: {schema}"
         )


### PR DESCRIPTION
## Summary
- expand `generate_tool_prompt` to accept tool registries or raw descriptors
- support MCP-style camelCase schemas and keep JSON output instructions
- test tool prompt generation for both local and MCP-sourced tools

## Testing
- `pytest tests/unit/test_tool_prompt.py -q` *(fails: command not found)*
- `python3 -m pytest tests/unit/test_tool_prompt.py -q` *(fails: No module named pytest)*

------
https://chatgpt.com/codex/tasks/task_e_68bd3e87d1f0832c8779ee37df8f7b68