### PR TITLE
feat: shardable FAISS index builder

### DIFF
--- a/src/langchain/lc_build_index.py
+++ b/src/langchain/lc_build_index.py
@@ -1,11 +1,14 @@
 #!/usr/bin/env python3
 from pathlib import Path
-import sys, json
+import json
 from typing import List
 from tqdm import tqdm
 from rich.pretty import pprint
 import re
 import os
+import math
+import shutil
+import argparse
 
 from langchain_community.document_loaders import PyMuPDFLoader
 from langchain_text_splitters import RecursiveCharacterTextSplitter
@@ -38,17 +41,64 @@ def write_chunks_jsonl(chunks: List[Document], out_path: Path):
             f.write(json.dumps(rec, ensure_ascii=False) + "\n")
 
 
-def build_faiss_for_models(chunks: List[Document], key: str, embedding_models: list[str]):
+def build_faiss_for_models(
+    chunks: List[Document],
+    key: str,
+    embedding_models: list[str],
+    shard_size: int = 1000,
+    resume: bool = False,
+    keep_shards: bool = False,
+):
     texts = [d.page_content for d in chunks]
     metadatas = [d.metadata for d in chunks]
+    n_shards = math.ceil(len(texts) / shard_size)
     for emb in embedding_models:
         emb_name = _fs_safe(emb)
-        vs_dir = Path(f"storage/faiss_{key}__{emb_name}")
-        vs_dir.mkdir(parents=True, exist_ok=True)
+        base_dir = Path(f"storage/faiss_{key}__{emb_name}")
+        shards_dir = base_dir / "shards"
+        shards_dir.mkdir(parents=True, exist_ok=True)
         embedder = HuggingFaceEmbeddings(model_name=emb)
-        vs = FAISS.from_texts(texts=texts, embedding=embedder, metadatas=metadatas)
-        vs.save_local(str(vs_dir))
-        print(f"[build] wrote FAISS: {vs_dir}")
+
+        for shard_idx, start in enumerate(
+            tqdm(
+                range(0, len(texts), shard_size),
+                total=n_shards,
+                desc=f"Shards {emb_name}",
+                unit="shard",
+            )
+        ):
+            shard_path = shards_dir / f"shard_{shard_idx:03d}"
+            if resume and (shard_path / "index.faiss").exists():
+                continue
+            slice_texts = texts[start : start + shard_size]
+            slice_metas = metadatas[start : start + shard_size]
+            vs = FAISS.from_texts(
+                texts=slice_texts, embedding=embedder, metadatas=slice_metas
+            )
+            vs.save_local(str(shard_path))
+
+        shard_paths = sorted(shards_dir.glob("shard_*"))
+        vectorstore = None
+        for shard_path in tqdm(
+            shard_paths, desc=f"Merging {emb_name}", unit="shard"
+        ):
+            vs = FAISS.load_local(
+                str(shard_path),
+                embeddings=embedder,
+                allow_dangerous_deserialization=True,
+            )
+            if vectorstore is None:
+                vectorstore = vs
+            else:
+                vectorstore.merge_from(vs)
+
+        base_dir.mkdir(parents=True, exist_ok=True)
+        if vectorstore is not None:
+            vectorstore.save_local(str(base_dir))
+            print(f"[build] wrote FAISS: {base_dir}")
+
+        if not keep_shards:
+            shutil.rmtree(shards_dir, ignore_errors=True)
 
 
 # ---------------------------------------------------------------------------
@@ -56,7 +106,6 @@ def build_faiss_for_models(chunks: List[Document], key: str, embedding_models: l
 # ---------------------------------------------------------------------------
 
 ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), '../..'))
-KEY = (sys.argv[1] if len(sys.argv) > 1 else os.getenv("RAG_KEY", "default")).strip() or "default"
 PDF_DIR = f"{ROOT}/data_raw"
 
 DOI_REGEX = re.compile(r'10\.\d{4,9}/[-._;()/:a-zA-Z0-9]*[a-zA-Z0-9]')
@@ -78,7 +127,7 @@ def load_pdfs() -> List[Document]:
                 meta_extended = json.loads(meta['subject'])
                 meta['doi'] = meta_extended['doi']
                 meta['isbn'] = meta_extended['isbn']
-            except ValueError as e: 
+            except ValueError:
                 if not notified_missing_metadata:
                  print('pdf from older version, has no extended metadata')
                  notified_missing_metadata = True
@@ -106,25 +155,55 @@ def get_doi(pages) -> str:
 # ---------------------------------------------------------------------------
 
 def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "key",
+        nargs="?",
+        default=os.getenv("RAG_KEY", "default"),
+        help="Storage key prefix",
+    )
+    parser.add_argument(
+        "--shard-size",
+        type=int,
+        default=1000,
+        help="Number of chunks per shard",
+    )
+    parser.add_argument(
+        "--resume", action="store_true", help="Skip shards already built"
+    )
+    parser.add_argument(
+        "--keep-shards",
+        action="store_true",
+        help="Do not delete shard directories after merge",
+    )
+    args = parser.parse_args()
+
+    key = (args.key or "default").strip() or "default"
+
     print("Parsing PDFs…")
     pages = load_pdfs()
     print(f"Splitting {len(pages)} pages into chunks…")
     splitter = RecursiveCharacterTextSplitter(
         chunk_size=1200, chunk_overlap=200, separators=["\n\n", "\n", " ", ""]
     )
-    chunks = list(tqdm(splitter.split_documents(pages), desc="Splitting", unit="chunk"))
+    chunks = list(
+        tqdm(splitter.split_documents(pages), desc="Splitting", unit="chunk")
+    )
 
     # Normalize chunks JSONL and build FAISS indexes for multiple models
-    chunks_out = Path(f"data_processed/lc_chunks_{KEY}.jsonl")
+    chunks_out = Path(f"data_processed/lc_chunks_{key}.jsonl")
     write_chunks_jsonl(chunks, chunks_out)
 
     build_faiss_for_models(
         chunks,
-        KEY,
+        key,
         embedding_models=[
             "BAAI/bge-small-en-v1.5",
             "BAAI/bge-large-en-v1.5",
         ],
+        shard_size=args.shard_size,
+        resume=args.resume,
+        keep_shards=args.keep_shards,
     )
 
 


### PR DESCRIPTION
## Summary
- add --shard-size, --resume, and --keep-shards CLI options
- build FAISS index in shards with progress feedback
- merge shards into final index and optionally clean up

## Testing
- `ruff check src/langchain/lc_build_index.py`
- `pytest` *(fails: Failed tests: test_run_batch_processing_receives_book_structure, test_try_ollama_success, test_try_ollama_import_error, test_json_outline_parsing, test_job_file_context, test_full_conversion_pipeline)*


------
https://chatgpt.com/codex/tasks/task_e_68bd96647630832c93821ac839b637f5