### PR TITLE
feat: add shard size and resume options for lc-index

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -90,12 +90,17 @@ ask:
 
 # ----- LangChain -----
 
-## Build FAISS index for LangChain retrieval [KEY=key_name]
+## Build FAISS index for LangChain retrieval [KEY=key_name] [SHARD_SIZE=n] [RESUME=0|1]
 lc-index:
-	@k="$(filter-out $@,$(MAKECMDGOALS))"; \
-	if [ -z "$$k" ]; then k="$(KEY)"; fi; \
-	if [ -z "$$k" ]; then k=default; fi; \
-	$(PY) $(ROOT)/src/langchain/lc_build_index.py "$$k"
+        @k="$(filter-out $@,$(MAKECMDGOALS))"; \
+        shard_size="$(SHARD_SIZE)"; \
+        resume="$(RESUME)"; \
+        if [ -z "$$k" ]; then k="$(KEY)"; fi; \
+        if [ -z "$$k" ]; then k=default; fi; \
+        cmd="$(PY) $(ROOT)/src/langchain/lc_build_index.py \"$$k\""; \
+        if [ -n "$$shard_size" ]; then cmd="$$cmd --shard-size \"$$shard_size\""; fi; \
+        if [ -n "$$resume" ]; then cmd="$$cmd --resume \"$$resume\""; fi; \
+        eval $$cmd
 
 ## Ask questions using LangChain RAG system
 ## Usage:

--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ make ask QUESTION="question"
 
 #### LangChain Content Generation
 ```bash
-make lc-index [KEY=key_name]                    # Build FAISS index
+make lc-index KEY=foo SHARD_SIZE=2000 RESUME=1  # Build FAISS index
 make lc-ask INSTR="instruction" [TASK="task"]   # RAG query with custom parameters
 make lc-batch FILE="jobs.jsonl" [PARALLEL=4]    # Batch processing
 make lc-merge-runner [SUB=1A1]                  # Content merging

--- a/docs/rag-writer.1
+++ b/docs/rag-writer.1
@@ -362,8 +362,8 @@ Ask questions using RAG (LlamaIndex)
 Alternative form using a named variable instead of a positional argument
 .SS LangChain Targets
 .TP
-.B make lc-index [KEY=key_name]
-Build FAISS index
+.B make lc-index KEY=foo SHARD_SIZE=2000 RESUME=1
+Build FAISS index with shard size control and resume support
 .TP
 .B make lc-ask INSTR="instruction" [TASK="task"]
 RAG query with custom parameters


### PR DESCRIPTION
## Summary
- allow `lc-index` Makefile target to pass optional `SHARD_SIZE` and `RESUME` variables to the index builder
- document how to use `SHARD_SIZE` and `RESUME` with `lc-index`

## Testing
- `make test` *(fails: Failed to initialize Ollama client; FileNotFoundError; non-zero exit status)*

------
https://chatgpt.com/codex/tasks/task_e_68bd96a7b228832cb87c61736c56ded1