### PR TITLE
Add shard cleanup utility and make target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -372,10 +372,17 @@ clean:
 ## Remove FAISS index for a specific KEY (inside container)
 ## Usage: make clean-faiss KEY=your_key
 clean-faiss:
-	@key="$(KEY)"; \
-	if [ -z "$$key" ]; then echo "Usage: make clean-faiss KEY=your_key"; exit 1; fi; \
-	rm -rf storage/faiss_"$$key" storage/faiss_"$$key"__*
-	@echo "✓ Removed FAISS index(es) for key: $(KEY)"
+        @key="$(KEY)"; \
+        if [ -z "$$key" ]; then echo "Usage: make clean-faiss KEY=your_key"; exit 1; fi; \
+        rm -rf storage/faiss_"$$key" storage/faiss_"$$key"__*
+        @echo "✓ Removed FAISS index(es) for key: $(KEY)"
+
+## Remove FAISS shard directories for a KEY and embedding model
+## Usage: make clean-shards KEY=your_key EMB=BAAI/bge-small-en-v1.5
+clean-shards:
+        @key="$(KEY)"; emb="$(EMB)"; \
+        if [ -z "$$key" ] || [ -z "$$emb" ]; then echo "Usage: make clean-shards KEY=your_key EMB=embed_model"; exit 1; fi; \
+        python src/langchain/cleanup_shards.py "$$key" "$$emb"
 
 ## Rebuild FAISS index for a KEY (inside container)
 ## Usage: make reindex KEY=your_key

--- a/README.md
+++ b/README.md
@@ -546,6 +546,7 @@ make compose-book-runner BOOK=outlines/converted_structures/my_book.json OUTPUT=
 
 # Index maintenance
 make clean-faiss KEY=your_key         # remove FAISS dirs for key
+make clean-shards KEY=your_key EMB=BAAI/bge-small-en-v1.5  # remove FAISS shards for model
 make reindex KEY=your_key             # clean + rebuild FAISS for key
 make repack-faiss KEY=your_key EMBED_MODEL=BAAI/bge-small-en-v1.5  # salvage old index
 

--- a/src/langchain/cleanup_shards.py
+++ b/src/langchain/cleanup_shards.py
@@ -1,0 +1,68 @@
+#!/usr/bin/env python3
+"""Remove FAISS shard directories for a specific collection key and embedding model.
+
+This script deletes temporary shard directories produced during multi-stage
+index builds. These directories follow the pattern::
+
+    storage/faiss_<KEY>__<EMB_MODEL_SAFE>__*
+
+Usage:
+    python src/langchain/cleanup_shards.py KEY EMB_MODEL
+
+Example:
+    python src/langchain/cleanup_shards.py science BAAI/bge-small-en-v1.5
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import shutil
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+def _fs_safe(s: str) -> str:
+    """Return a filesystem safe version of *s*."""
+    return re.sub(r"[^a-zA-Z0-9._-]+", "-", s)
+
+
+def cleanup_shards(key: str, embed_model: str, storage_dir: Path | None = None) -> int:
+    """Remove shard directories for *key* and *embed_model*.
+
+    Args:
+        key: Collection key.
+        embed_model: Embedding model name.
+        storage_dir: Base storage directory (defaults to project ``storage``).
+
+    Returns:
+        Number of shard directories removed.
+    """
+    storage = storage_dir or ROOT / "storage"
+    emb_safe = _fs_safe(embed_model)
+    prefix = f"faiss_{key}__{emb_safe}__"
+    removed = 0
+    for path in storage.glob(prefix + "*"):
+        if path.is_dir():
+            shutil.rmtree(path, ignore_errors=True)
+            print(f"Removed {path}")
+            removed += 1
+    if removed == 0:
+        print("No shard directories found.")
+    else:
+        print(f"Removed {removed} shard directory{'ies' if removed != 1 else ''}.")
+    return removed
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("key", help="Collection key")
+    parser.add_argument("embed_model", help="Embedding model name")
+    parser.add_argument("--storage", default=str(ROOT / "storage"), help="Storage directory")
+    args = parser.parse_args()
+    cleanup_shards(args.key, args.embed_model, Path(args.storage))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add `cleanup_shards.py` to remove FAISS shard directories for a key and embedding model
- expose cleanup via `make clean-shards KEY=... EMB=...`
- document shard cleanup target in README

## Testing
- `pytest` *(fails: RuntimeError: Failed to initialize Ollama client, FileNotFoundError: No such file or directory, TypeError: cannot unpack non-iterable NoneType object)*

------
https://chatgpt.com/codex/tasks/task_e_68bd96c3bc10832cbab92d906de4936f