### PR TITLE
Add lc_index wrapper to delegate to lc_build_index

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -95,7 +95,7 @@ lc-index:
 	@k="$(filter-out $@,$(MAKECMDGOALS))"; \
 	if [ -z "$$k" ]; then k="$(KEY)"; fi; \
 	if [ -z "$$k" ]; then k=default; fi; \
-	$(PY) $(ROOT)/src/langchain/lc_build_index.py "$$k"
+        $(PY) $(ROOT)/src/langchain/lc_index.py "$$k"
 
 ## Ask questions using LangChain RAG system
 ## Usage:

--- a/src/langchain/lc_index.py
+++ b/src/langchain/lc_index.py
@@ -1,0 +1,10 @@
+#!/usr/bin/env python3
+"""Backward-compatible wrapper for lc_build_index."""
+
+try:
+    from .lc_build_index import main
+except ImportError:  # pragma: no cover - fallback for direct script execution
+    from lc_build_index import main
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add `src/langchain/lc_index.py` as a backward-compatible wrapper calling `lc_build_index.main`
- update `lc-index` Makefile target to execute the new wrapper so existing scripts continue to work

## Testing
- `pytest -q` *(fails: TestBookRunnerVariableScoping::test_run_batch_processing_receives_book_structure, TestLLMFactory::test_try_ollama_success, TestLLMFactory::test_try_ollama_import_error, TestJSONOutlineParsing::test_json_outline_parsing, TestJobFileGeneration::test_job_file_context, TestIntegration::test_full_conversion_pipeline)*

------
https://chatgpt.com/codex/tasks/task_e_68bd99288998832cb16c43661b92d5dd