### PR TITLE
Handle resume flag value in lc_build_index shard build

### DIFF
--- a/src/langchain/lc_build_index.py
+++ b/src/langchain/lc_build_index.py
@@ -182,7 +182,11 @@ def main():
         help="Number of chunks per shard",
     )
     parser.add_argument(
-        "--resume", action="store_true", help="Skip shards already built"
+        "--resume",
+        nargs="?",
+        const=True,
+        default=False,
+        help="Skip shards already built (accepts optional value for compatibility)",
     )
     parser.add_argument(
         "--keep-shards",
@@ -207,6 +211,8 @@ def main():
     chunks_out = Path(f"data_processed/lc_chunks_{key}.jsonl")
     write_chunks_jsonl(chunks, chunks_out)
 
+    resume_flag = bool(args.resume)
+
     build_faiss_for_models(
         chunks,
         key,
@@ -215,7 +221,7 @@ def main():
             "BAAI/bge-large-en-v1.5",
         ],
         shard_size=args.shard_size,
-        resume=args.resume,
+        resume=resume_flag,
         keep_shards=args.keep_shards,
     )
 

--- a/tests/langchain/test_lc_build_index_resume.py
+++ b/tests/langchain/test_lc_build_index_resume.py
@@ -1,0 +1,22 @@
+import sys
+from langchain_core.documents import Document
+from src.langchain import lc_build_index
+
+
+def test_lc_build_index_accepts_resume_value(monkeypatch):
+    docs = [Document(page_content="test", metadata={})]
+    monkeypatch.setattr(lc_build_index, "load_pdfs", lambda: docs)
+    monkeypatch.setattr(lc_build_index, "write_chunks_jsonl", lambda chunks, out: None)
+
+    called = {}
+
+    def fake_build(chunks, key, embedding_models, shard_size, resume, keep_shards):
+        called["resume"] = resume
+
+    monkeypatch.setattr(lc_build_index, "build_faiss_for_models", fake_build)
+
+    monkeypatch.setattr(sys, "argv", ["lc_build_index.py", "foo", "--resume", "1"])
+
+    lc_build_index.main()
+
+    assert called["resume"] is True


### PR DESCRIPTION
## Summary
- allow `lc_build_index` to accept `--resume` with an optional value
- add regression test for resume flag with value

## Testing
- `make fmt`
- `make lint` *(fails: flake8 E/W errors in unrelated files)*
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68c3ff833c9c832c9c3d49ac612b3594