### PR TITLE
Add agent runner using ToolRegistry for multi-shot RAG

### DIFF
--- a/src/cli/agent_runner.py
+++ b/src/cli/agent_runner.py
@@ -1,0 +1,24 @@
+"""Simple agent orchestrator leveraging a RAG retrieval tool."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from src.tool import ToolRegistry, create_rag_retrieve_tool, run_agent
+
+
+def run_agent_with_retrieval(question: str, llm: Any, faiss_key: str) -> str:
+    """Run the tool-enabled agent for a question using a FAISS index key.
+
+    Parameters
+    ----------
+    question:
+        The user question posed to the agent.
+    llm:
+        Language model instance compatible with :func:`run_agent`.
+    faiss_key:
+        Key of the FAISS index used to create the retrieval tool.
+    """
+    registry = ToolRegistry()
+    registry.register(create_rag_retrieve_tool(faiss_key))
+    return run_agent(llm, registry, question)

--- a/tests/unit/test_agent_runner.py
+++ b/tests/unit/test_agent_runner.py
@@ -1,0 +1,37 @@
+import json
+from src.cli.agent_runner import run_agent_with_retrieval
+from src.tool import Tool, ToolSpec
+
+
+def test_run_agent_with_retrieval_registers_tool_and_calls_agent(monkeypatch):
+    """Ensure registry registers RAG tool and run_agent is invoked."""
+    called = {}
+
+    def fake_create_tool(key: str) -> Tool:
+        called['key'] = key
+        spec = ToolSpec(
+            name="rag_retrieve",
+            description="",
+            input_schema={},
+            output_schema={},
+        )
+        return Tool(spec, lambda **_: {})
+
+    def fake_run_agent(llm, registry, question, max_iters=5, system_prompt=None):
+        called['question'] = question
+        called['tools'] = list(registry.list_tools())
+        return "ANSWER"
+
+    monkeypatch.setattr("src.cli.agent_runner.create_rag_retrieve_tool", fake_create_tool)
+    monkeypatch.setattr("src.cli.agent_runner.run_agent", fake_run_agent)
+
+    class DummyLLM:
+        def __call__(self, messages):
+            return json.dumps({"final": "done"})
+
+    result = run_agent_with_retrieval("hi", DummyLLM(), "faiss_key")
+
+    assert result == "ANSWER"
+    assert called['key'] == "faiss_key"
+    assert "rag_retrieve" in called['tools']
+    assert called['question'] == "hi"


### PR DESCRIPTION
## Summary
- add `run_agent_with_retrieval` helper to orchestrate an agent with a FAISS-backed retrieval tool
- cover agent registry wiring with new unit test

## Testing
- `make fmt`
- `make lint` *(fails: line too long, unused imports, etc.)*
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68c42b59a3a0832caaa4ac127b6683bb