### PR TITLE
Add multi-agent CLI orchestrating RAG and MCP tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -1393,6 +1393,20 @@ Start the tool server to expose registered tools via the Model Context Protocol:
 python -m src.tool.mcp_server  # or: make tool-shell
 ```
 
+### Multi-agent CLI
+
+Run a tool-enabled agent that combines local RAG retrieval with tools served
+over MCP:
+
+```bash
+python -m src.cli.multi_agent "Find papers on transformers and call the time tool" \
+  --key default --mcp ./tools/mcp_server.py
+```
+
+The command registers the `rag_retrieve` tool for vector search and loads any
+tools exposed by the MCP server so the agent can invoke them during the
+conversation.
+
 ## 🔍 Troubleshooting
 
 ### Common Issues

--- a/src/cli/multi_agent.py
+++ b/src/cli/multi_agent.py
@@ -1,0 +1,35 @@
+"""CLI entry point for a tool-enabled multi-agent conversation."""
+
+from __future__ import annotations
+
+import asyncio
+import typer
+
+from ..core.llm import LLMFactory
+from ..tool import ToolRegistry, create_rag_retrieve_tool, run_agent
+
+app = typer.Typer(add_completion=False)
+
+
+@app.command()
+def ask(
+    question: str = typer.Argument(..., help="Question to pass to the agent"),
+    key: str = typer.Option("default", "--key", "-k", help="FAISS index key"),
+    mcp: str | None = typer.Option(
+        None, "--mcp", help="Path to MCP server executable to register tools from"
+    ),
+) -> None:
+    """Run the agent loop with RAG and optional MCP tools."""
+    registry = ToolRegistry()
+    registry.register(create_rag_retrieve_tool(key))
+    if mcp:
+        asyncio.run(registry.register_mcp_server(mcp))
+
+    factory = LLMFactory()
+    _, llm = factory.create_llm()
+    result = run_agent(llm, registry, question)
+    typer.echo(result)
+
+
+if __name__ == "__main__":
+    app()

--- a/tests/unit/test_cli_multi_agent.py
+++ b/tests/unit/test_cli_multi_agent.py
@@ -1,0 +1,52 @@
+from typer.testing import CliRunner
+
+from src.cli import multi_agent
+
+
+class DummyRegistry:
+    def __init__(self):
+        self.registered_tool = None
+        self.mcp_url = None
+
+    def register(self, tool):
+        self.registered_tool = tool
+
+    async def register_mcp_server(self, url: str):
+        self.mcp_url = url
+
+
+def test_cli_invokes_agent_with_tools(monkeypatch):
+    registry = DummyRegistry()
+    monkeypatch.setattr(multi_agent, "ToolRegistry", lambda: registry)
+
+    def fake_create_tool(key: str):
+        fake_create_tool.called_with = key
+        return object()
+
+    fake_create_tool.called_with = None
+    monkeypatch.setattr(multi_agent, "create_rag_retrieve_tool", fake_create_tool)
+
+    mock_llm = object()
+
+    class FakeFactory:
+        def create_llm(self):
+            return ("backend", mock_llm)
+
+    monkeypatch.setattr(multi_agent, "LLMFactory", lambda: FakeFactory())
+
+    def fake_run_agent(llm, reg, question):
+        assert llm is mock_llm
+        assert reg is registry
+        assert question == "where?"
+        return "done"
+
+    monkeypatch.setattr(multi_agent, "run_agent", fake_run_agent)
+
+    runner = CliRunner()
+    result = runner.invoke(multi_agent.app, ["where?", "--key", "paper", "--mcp", "server"])
+
+    assert result.exit_code == 0
+    assert "done" in result.stdout
+    assert registry.registered_tool is not None
+    assert registry.mcp_url == "server"
+    assert fake_create_tool.called_with == "paper"


### PR DESCRIPTION
## Summary
- add Typer-based `multi_agent` CLI that wires up `LLMFactory`, RAG retrieval tool and optional MCP server
- document usage of the multi-agent CLI in README
- test the new CLI for proper tool registration and agent execution

## Testing
- `make fmt`
- `make lint` *(fails: tests/unit/test_outline_converter.py:321:80: E501 line too long (80 > 79 characters))*
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_68c43005fc98832c921d34aa40655e6f