### PR TITLE
Add FastAPI MCP HTTP server with envelope

### DIFF
--- a/README.md
+++ b/README.md
@@ -744,6 +744,7 @@ Start the tool server to expose registered tools via the Model Context Protocol:
 
 ```bash
 python -m src.tool.mcp_server  # or: make tool-shell
+uvicorn src.tool.mcp_app:app --host 127.0.0.1 --port 3333
 ```
 
 ---
@@ -788,6 +789,35 @@ args = parser.parse_args()
 ```python
 # returns a value such as image/png, application/pdf, text/html
 mime_type = magic.from_file(filepath, mime=True)
+```
+
+### FastAPI
+[Documentation](https://fastapi.tiangolo.com/): FastAPI is a modern, high-performance web framework for building APIs with Python.
+
+**Example Usage**:
+```python
+from fastapi import FastAPI
+
+app = FastAPI()
+```
+
+### Uvicorn
+[Documentation](https://www.uvicorn.org/): Uvicorn is a lightning-fast ASGI server implementation, perfect for serving FastAPI apps.
+
+**Example Usage**:
+```bash
+uvicorn src.tool.mcp_app:app --host 127.0.0.1 --port 3333
+```
+
+### Pydantic
+[Documentation](https://docs.pydantic.dev/): Pydantic provides data validation and settings management using Python type annotations.
+
+**Example Usage**:
+```python
+from pydantic import BaseModel
+
+class Meta(BaseModel):
+    traceId: str
 ```
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -48,3 +48,6 @@ langchain-ollama>=0.1.0
 langchain-openai>=0.1.7
 
 mcp
+fastapi
+uvicorn[standard]
+pydantic

--- a/src/tool/deps.py
+++ b/src/tool/deps.py
@@ -1,0 +1,12 @@
+from fastapi import HTTPException, Request, status
+
+MAX_IN = 65536
+
+
+async def size_guard(request: Request) -> None:
+    body = await request.body()
+    if len(body) > MAX_IN:
+        raise HTTPException(
+            status_code=status.HTTP_413_REQUEST_ENTITY_TOO_LARGE,
+            detail="Request too large",
+        )

--- a/src/tool/mcp_app.py
+++ b/src/tool/mcp_app.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+from time import perf_counter
+from typing import Dict
+
+from fastapi import Depends, FastAPI
+
+from .deps import size_guard
+from .models import Envelope, Meta
+from .service import discover, get_prompt, invoke_tool
+
+app = FastAPI()
+
+
+@app.get("/mcp/discover")
+async def mcp_discover() -> Dict[str, object]:
+    return discover()
+
+
+@app.get("/mcp/prompt/{domain}/{name}/{major}")
+async def mcp_prompt(domain: str, name: str, major: str) -> Dict[str, object]:
+    return get_prompt(domain, name, major)
+
+
+@app.post("/mcp/tool/{tool_name}", response_model=Envelope)
+async def mcp_tool(
+    tool_name: str, payload: Dict[str, object], _: None = Depends(size_guard)
+) -> Envelope:
+    start = perf_counter()
+    result = invoke_tool(tool_name, payload)
+    duration_ms = int((perf_counter() - start) * 1000)
+    meta = Meta(durationMs=duration_ms)
+    return Envelope(meta=meta, body=result)

--- a/src/tool/models.py
+++ b/src/tool/models.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+from typing import Any, Optional
+from uuid import UUID, uuid4
+
+from pydantic import BaseModel, Field
+
+
+class Meta(BaseModel):
+    traceId: UUID = Field(default_factory=uuid4)
+    durationMs: int = 0
+
+
+class ErrorItem(BaseModel):
+    code: str
+    message: str
+
+
+class Envelope(BaseModel):
+    meta: Meta = Field(default_factory=Meta)
+    body: Any | None = None
+    error: Optional[ErrorItem] = None
+    warnings: list[str] = Field(default_factory=list)

--- a/src/tool/service.py
+++ b/src/tool/service.py
@@ -1,0 +1,18 @@
+from __future__ import annotations
+
+from typing import Any, Dict
+
+
+def discover() -> Dict[str, Any]:
+    return {"mcp": "stub", "endpoints": ["discover", "prompt", "tool"]}
+
+
+def get_prompt(domain: str, name: str, major: str) -> Dict[str, Any]:
+    return {
+        "body": f"{domain}-{name}-{major}",
+        "spec": {"domain": domain, "name": name, "major": major},
+    }
+
+
+def invoke_tool(tool: str, payload: Dict[str, Any]) -> Dict[str, Any]:
+    return {"tool": tool, "payload": payload}

--- a/tests/unit/test_mcp_app.py
+++ b/tests/unit/test_mcp_app.py
@@ -1,0 +1,47 @@
+import sys
+from types import ModuleType, SimpleNamespace
+
+from fastapi.testclient import TestClient
+
+# Stub optional MCP dependency so importing src.tool succeeds
+mcp_stub = ModuleType("mcp")
+mcp_stub.__path__ = []
+mcp_stub.ClientSession = object
+client_mod = ModuleType("mcp.client")
+client_mod.stdio = SimpleNamespace(StdioServerParameters=object, stdio_client=None)
+mcp_stub.client = client_mod
+sys.modules.setdefault("mcp", mcp_stub)
+sys.modules.setdefault("mcp.client", client_mod)
+
+from src.tool.mcp_app import app  # noqa: E402
+
+client = TestClient(app)
+
+
+def test_discover_endpoint():
+    res = client.get("/mcp/discover")
+    assert res.status_code == 200
+    assert res.json()["mcp"] == "stub"
+
+
+def test_prompt_endpoint():
+    res = client.get("/mcp/prompt/foo/bar/1")
+    assert res.status_code == 200
+    data = res.json()
+    assert data["spec"] == {"domain": "foo", "name": "bar", "major": "1"}
+    assert data["body"] == "foo-bar-1"
+
+
+def test_tool_endpoint_envelope():
+    res = client.post("/mcp/tool/echo", json={"hello": "world"})
+    assert res.status_code == 200
+    out = res.json()
+    assert "meta" in out and "traceId" in out["meta"] and "durationMs" in out["meta"]
+    assert out["body"] == {"tool": "echo", "payload": {"hello": "world"}}
+    assert out["warnings"] == []
+
+
+def test_tool_endpoint_size_guard():
+    payload = {"data": "x" * 70000}
+    res = client.post("/mcp/tool/echo", json=payload)
+    assert res.status_code == 413


### PR DESCRIPTION
## Summary
- add Pydantic envelope models and stub services for MCP
- implement FastAPI MCP app with size guard and three endpoints
- document run command and add FastAPI, Uvicorn, Pydantic dependencies

## Testing
- `ruff check --fix src/tool/deps.py src/tool/mcp_app.py src/tool/models.py src/tool/service.py tests/unit/test_mcp_app.py`
- `make lint` *(fails: E501 line too long)*
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68c4ad85bf60832ca6acb791f9a06823