### PR TITLE
feat: load prompts from disk

### DIFF
--- a/README.md
+++ b/README.md
@@ -919,6 +919,36 @@ This ensures that new content types can inherit templates from the default confi
 
 Defines different merge pipeline configurations for content consolidation and editing.
 
+### Prompt Packs and Registry
+
+**File**: `prompts/REGISTRY.yaml`
+
+Prompt packs are stored on disk and registered via `prompts/REGISTRY.yaml`. Each prompt family contains one or more versions. Bodies live in Markdown files named `prompts/packs/<domain>/<name>.v<major>.md` and share a spec defined in `prompts/packs/<domain>/<name>.spec.yaml`.
+
+**Example Registry Structure**:
+
+```yaml
+writing:
+  sectioned_draft:
+    - 3
+```
+
+**Example Spec Structure** (`sectioned_draft.spec.yaml`):
+
+```yaml
+inputs:
+  type: object
+  properties:
+    topic:
+      type: string
+  required:
+    - topic
+  additionalProperties: false
+constraints:
+  length:
+    max_tokens: 1000
+```
+
 **Available Merge Types:**
 - `generic_editor` - Basic single-stage merging
 - `advanced_pipeline` - Multi-stage critique → merge → style → images

--- a/prompts/REGISTRY.yaml
+++ b/prompts/REGISTRY.yaml
@@ -1,0 +1,3 @@
+writing:
+  sectioned_draft:
+    - 3

--- a/prompts/packs/writing/sectioned_draft.spec.yaml
+++ b/prompts/packs/writing/sectioned_draft.spec.yaml
@@ -1,0 +1,11 @@
+inputs:
+  type: object
+  properties:
+    topic:
+      type: string
+  required:
+    - topic
+  additionalProperties: false
+constraints:
+  length:
+    max_tokens: 1000

--- a/prompts/packs/writing/sectioned_draft.v3.md
+++ b/prompts/packs/writing/sectioned_draft.v3.md
@@ -1,0 +1,3 @@
+# Sectioned Draft v3
+
+Write a sectioned draft about the provided topic.

--- a/src/tool/service.py
+++ b/src/tool/service.py
@@ -1,17 +1,47 @@
 from __future__ import annotations
 
+from pathlib import Path
 from typing import Any, Dict
+
+import yaml
+from fastapi import HTTPException
+
+REGISTRY_PATH = Path("prompts/REGISTRY.yaml")
+PACKS_DIR = Path("prompts/packs")
+
+
+def _load_registry() -> Dict[str, Dict[str, list[int]]]:
+    if not REGISTRY_PATH.exists():
+        return {}
+    data = yaml.safe_load(REGISTRY_PATH.read_text())
+    return data or {}
 
 
 def discover() -> Dict[str, Any]:
-    return {"mcp": "stub", "endpoints": ["discover", "prompt", "tool"]}
+    registry = _load_registry()
+    return {
+        "mcp": "stub",
+        "endpoints": ["discover", "prompt", "tool"],
+        "prompts": registry,
+    }
 
 
 def get_prompt(domain: str, name: str, major: str) -> Dict[str, Any]:
-    return {
-        "body": f"{domain}-{name}-{major}",
-        "spec": {"domain": domain, "name": name, "major": major},
-    }
+    registry = _load_registry()
+    versions = registry.get(domain, {}).get(name)
+    if versions is None or int(major) not in versions:
+        raise HTTPException(status_code=404, detail="Prompt not found")
+
+    body_path = PACKS_DIR / domain / f"{name}.v{major}.md"
+    spec_path = PACKS_DIR / domain / f"{name}.spec.yaml"
+
+    if not body_path.exists() or not spec_path.exists():
+        raise HTTPException(status_code=404, detail="Prompt not found")
+
+    body = body_path.read_text()
+    spec = yaml.safe_load(spec_path.read_text())
+
+    return {"body": body, "spec": spec}
 
 
 def invoke_tool(tool: str, payload: Dict[str, Any]) -> Dict[str, Any]:

--- a/tests/unit/test_mcp_app.py
+++ b/tests/unit/test_mcp_app.py
@@ -21,15 +21,24 @@ client = TestClient(app)
 def test_discover_endpoint():
     res = client.get("/mcp/discover")
     assert res.status_code == 200
-    assert res.json()["mcp"] == "stub"
+    data = res.json()
+    assert data["mcp"] == "stub"
+    assert data["prompts"] == {"writing": {"sectioned_draft": [3]}}
 
 
 def test_prompt_endpoint():
-    res = client.get("/mcp/prompt/foo/bar/1")
+    res = client.get("/mcp/prompt/writing/sectioned_draft/3")
     assert res.status_code == 200
     data = res.json()
-    assert data["spec"] == {"domain": "foo", "name": "bar", "major": "1"}
-    assert data["body"] == "foo-bar-1"
+    assert "Write a sectioned draft" in data["body"]
+    assert (
+        data["spec"]["inputs"]["properties"]["topic"]["type"] == "string"
+    )
+
+
+def test_prompt_not_found():
+    res = client.get("/mcp/prompt/writing/does_not_exist/1")
+    assert res.status_code == 404
 
 
 def test_tool_endpoint_envelope():


### PR DESCRIPTION
## Summary
- serve prompts from `prompts/packs` and validate against `REGISTRY.yaml`
- expose prompt metadata via `/mcp/discover`
- document prompt registry and pack layout

## Testing
- `make fmt`
- `make lint` *(fails: src/langchain/lc_merge_runner.py:45:80: E501 line too long (88 > 79 characters))*
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c4ce56c294832cb0c008e1ad7a3b53