### PR TITLE
Add canonical tool schemas with output validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -724,6 +724,13 @@ or a final response:
 
 See [docs/tool_agent_schema.md](docs/tool_agent_schema.md) for the full specification and transcript example.
 
+### Canonical Tool Schemas
+
+Canonical tool input and output JSON schemas live under `schemas/tools/`. Each tool,
+such as `web_search_query` or `vector_query_search`, has corresponding
+`*.input.schema.json` and `*.output.schema.json` files that define the expected
+Model Context Protocol contracts.
+
 ### Multi-agent CLI
 
 Run a tool-enabled agent that combines local RAG retrieval with tools served

--- a/requirements.txt
+++ b/requirements.txt
@@ -51,3 +51,4 @@ mcp
 fastapi
 uvicorn[standard]
 pydantic
+jsonschema

--- a/schemas/tools/citations_audit_check.input.schema.json
+++ b/schemas/tools/citations_audit_check.input.schema.json
@@ -1,0 +1,14 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "citations_audit_check.input",
+  "type": "object",
+  "properties": {
+    "citations": {
+      "type": "array",
+      "items": {"type": "string"},
+      "minItems": 1
+    }
+  },
+  "required": ["citations"],
+  "additionalProperties": false
+}

--- a/schemas/tools/citations_audit_check.output.schema.json
+++ b/schemas/tools/citations_audit_check.output.schema.json
@@ -1,0 +1,22 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "citations_audit_check.output",
+  "type": "object",
+  "properties": {
+    "reports": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "citation": {"type": "string"},
+          "valid": {"type": "boolean"},
+          "reason": {"type": "string"}
+        },
+        "required": ["citation", "valid", "reason"],
+        "additionalProperties": false
+      }
+    }
+  },
+  "required": ["reports"],
+  "additionalProperties": false
+}

--- a/schemas/tools/docs_load_fetch.input.schema.json
+++ b/schemas/tools/docs_load_fetch.input.schema.json
@@ -1,0 +1,14 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "docs_load_fetch.input",
+  "type": "object",
+  "properties": {
+    "doc_ids": {
+      "type": "array",
+      "items": {"type": "string"},
+      "minItems": 1
+    }
+  },
+  "required": ["doc_ids"],
+  "additionalProperties": false
+}

--- a/schemas/tools/docs_load_fetch.output.schema.json
+++ b/schemas/tools/docs_load_fetch.output.schema.json
@@ -1,0 +1,21 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "docs_load_fetch.output",
+  "type": "object",
+  "properties": {
+    "docs": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "id": {"type": "string"},
+          "content": {"type": "string"}
+        },
+        "required": ["id", "content"],
+        "additionalProperties": false
+      }
+    }
+  },
+  "required": ["docs"],
+  "additionalProperties": false
+}

--- a/schemas/tools/exports_render_markdown.input.schema.json
+++ b/schemas/tools/exports_render_markdown.input.schema.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "exports_render_markdown.input",
+  "type": "object",
+  "properties": {
+    "text": {"type": "string"}
+  },
+  "required": ["text"],
+  "additionalProperties": false
+}

--- a/schemas/tools/exports_render_markdown.output.schema.json
+++ b/schemas/tools/exports_render_markdown.output.schema.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "exports_render_markdown.output",
+  "type": "object",
+  "properties": {
+    "markdown": {"type": "string"}
+  },
+  "required": ["markdown"],
+  "additionalProperties": false
+}

--- a/schemas/tools/vector_query_search.input.schema.json
+++ b/schemas/tools/vector_query_search.input.schema.json
@@ -1,0 +1,11 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "vector_query_search.input",
+  "type": "object",
+  "properties": {
+    "query": {"type": "string"},
+    "top_k": {"type": "integer", "minimum": 1}
+  },
+  "required": ["query"],
+  "additionalProperties": false
+}

--- a/schemas/tools/vector_query_search.output.schema.json
+++ b/schemas/tools/vector_query_search.output.schema.json
@@ -1,0 +1,22 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "vector_query_search.output",
+  "type": "object",
+  "properties": {
+    "results": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "id": {"type": "string"},
+          "score": {"type": "number"},
+          "content": {"type": "string"}
+        },
+        "required": ["id", "score", "content"],
+        "additionalProperties": false
+      }
+    }
+  },
+  "required": ["results"],
+  "additionalProperties": false
+}

--- a/schemas/tools/web_search_query.input.schema.json
+++ b/schemas/tools/web_search_query.input.schema.json
@@ -1,0 +1,11 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "web_search_query.input",
+  "type": "object",
+  "properties": {
+    "query": {"type": "string"},
+    "max_results": {"type": "integer", "minimum": 1}
+  },
+  "required": ["query"],
+  "additionalProperties": false
+}

--- a/schemas/tools/web_search_query.output.schema.json
+++ b/schemas/tools/web_search_query.output.schema.json
@@ -1,0 +1,22 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "web_search_query.output",
+  "type": "object",
+  "properties": {
+    "results": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "title": {"type": "string"},
+          "url": {"type": "string"},
+          "snippet": {"type": "string"}
+        },
+        "required": ["title", "url", "snippet"],
+        "additionalProperties": false
+      }
+    }
+  },
+  "required": ["results"],
+  "additionalProperties": false
+}

--- a/src/tool/__init__.py
+++ b/src/tool/__init__.py
@@ -4,6 +4,7 @@ from .base import Tool, ToolSpec, ToolRegistry
 from .agent import run_agent
 from .rag_tool import create_rag_retrieve_tool
 from .mcp_client import connect, fetch_tools, call_tool
+from . import schemas
 
 __all__ = [
     "Tool",
@@ -14,4 +15,5 @@ __all__ = [
     "connect",
     "fetch_tools",
     "call_tool",
+    "schemas",
 ]

--- a/src/tool/schemas.py
+++ b/src/tool/schemas.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any, Dict
+
+from jsonschema import Draft7Validator
+
+SCHEMAS_DIR = Path(__file__).resolve().parents[2] / "schemas" / "tools"
+
+INPUT_VALIDATORS: Dict[str, Draft7Validator] = {}
+OUTPUT_VALIDATORS: Dict[str, Draft7Validator] = {}
+
+for path in SCHEMAS_DIR.glob("*.input.schema.json"):
+    tool = path.name.split(".")[0]
+    with path.open("r", encoding="utf-8") as f:
+        schema = json.load(f)
+    INPUT_VALIDATORS[tool] = Draft7Validator(schema)
+
+for path in SCHEMAS_DIR.glob("*.output.schema.json"):
+    tool = path.name.split(".")[0]
+    with path.open("r", encoding="utf-8") as f:
+        schema = json.load(f)
+    OUTPUT_VALIDATORS[tool] = Draft7Validator(schema)
+
+
+def validate_tool_output(tool: str, data: Dict[str, Any]) -> None:
+    validator = OUTPUT_VALIDATORS.get(tool)
+    if validator is None:
+        raise KeyError(f"No output schema for tool: {tool}")
+    validator.validate(data)

--- a/tests/tool/test_tool_schemas.py
+++ b/tests/tool/test_tool_schemas.py
@@ -1,0 +1,27 @@
+import pytest
+from fastapi import HTTPException
+
+
+def test_invoke_tool_stub_outputs_valid():
+    from src.tool.service import invoke_tool
+
+    assert invoke_tool("web_search_query", {}) == {"results": []}
+
+
+def test_invoke_tool_schema_violation(monkeypatch):
+    from src.tool import service
+
+    monkeypatch.setitem(service.STUB_OUTPUTS, "web_search_query", {})
+    with pytest.raises(HTTPException) as exc:
+        service.invoke_tool("web_search_query", {})
+    assert exc.value.status_code == 400
+    assert exc.value.detail["error"] == "schema_validation_failed"
+
+
+def test_schemas_compile_and_validate():
+    from src.tool import schemas
+    import jsonschema
+
+    schemas.validate_tool_output("web_search_query", {"results": []})
+    with pytest.raises(jsonschema.ValidationError):
+        schemas.validate_tool_output("web_search_query", {})


### PR DESCRIPTION
## Summary
- add input/output JSON Schemas for canonical tools under `schemas/tools`
- load schemas at runtime and validate tool outputs
- validate `invoke_tool` responses and document canonical schemas

## Testing
- `ruff check --fix src/tool/schemas.py src/tool/service.py tests/tool/test_tool_schemas.py README.md`
- `black src/tool/schemas.py src/tool/service.py tests/tool/test_tool_schemas.py`
- `flake8 src/tool/schemas.py src/tool/service.py tests/tool/test_tool_schemas.py`
- `pytest tests/tool/test_tool_schemas.py -q`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c4d1237a90832c97173470c2b50968