### PR TITLE
feat: enforce invoke_tool idempotency and bounds

### DIFF
--- a/tests/tool/test_mcp_stdio.py
+++ b/tests/tool/test_mcp_stdio.py
@@ -40,7 +40,10 @@ def test_stdio_discover_and_invoke():
                 "params": {"tool": "echo", "payload": {"hello": "world"}},
             },
         )
-        assert resp2["result"] == {"tool": "echo", "payload": {"hello": "world"}}
+        assert resp2["result"] == {
+            "ok": True,
+            "data": {"tool": "echo", "payload": {"hello": "world"}},
+        }
     finally:
         proc.terminate()
         proc.wait(timeout=3)

--- a/tests/tool/test_service_contracts.py
+++ b/tests/tool/test_service_contracts.py
@@ -1,0 +1,52 @@
+import json
+import time
+
+import pytest
+from fastapi import HTTPException
+
+from src.tool import service
+
+
+def test_invoke_tool_idempotent(monkeypatch):
+    calls = {"count": 0}
+
+    def fake_run(tool, payload):
+        calls["count"] += 1
+        return {"call": calls["count"]}
+
+    monkeypatch.setattr(service, "_run_tool", fake_run)
+    first = service.invoke_tool("echo", {"a": 1, "b": 2})
+    second = service.invoke_tool("echo", {"b": 2, "a": 1})
+    assert first == second == {"ok": True, "data": {"call": 1}}
+    assert calls["count"] == 1
+
+
+def test_invoke_tool_input_limit():
+    big_payload = {"data": "x" * 70000}
+    with pytest.raises(HTTPException) as exc:
+        service.invoke_tool("echo", big_payload)
+    assert exc.value.status_code == 400
+    assert exc.value.detail["error"] == "INVALID_INPUT"
+
+
+def test_invoke_tool_output_limit(monkeypatch):
+    def big_run(tool, payload):
+        return {"data": "x" * 300000}
+
+    monkeypatch.setattr(service, "_run_tool", big_run)
+    with pytest.raises(HTTPException) as exc:
+        service.invoke_tool("echo", {})
+    assert exc.value.status_code == 500
+    assert exc.value.detail["error"] == "INTERNAL"
+    assert exc.value.detail["details"]["size"] > 256 * 1024
+
+
+def test_invoke_tool_timeout(monkeypatch):
+    def slow_run(tool, payload):
+        time.sleep(0.2)
+        return {}
+
+    monkeypatch.setattr(service, "_run_tool", slow_run)
+    with pytest.raises(HTTPException) as exc:
+        service.invoke_tool("slow", {}, timeout=0.05)
+    assert exc.value.detail["error"] == "TIMEOUT"

--- a/tests/tool/test_tool_schemas.py
+++ b/tests/tool/test_tool_schemas.py
@@ -5,13 +5,14 @@ from fastapi import HTTPException
 def test_invoke_tool_stub_outputs_valid():
     from src.tool.service import invoke_tool
 
-    assert invoke_tool("web_search_query", {}) == {"results": []}
+    assert invoke_tool("web_search_query", {}) == {"ok": True, "data": {"results": []}}
 
 
 def test_invoke_tool_schema_violation(monkeypatch):
     from src.tool import service
 
     monkeypatch.setitem(service.STUB_OUTPUTS, "web_search_query", {})
+    service._CACHE.clear()
     with pytest.raises(HTTPException) as exc:
         service.invoke_tool("web_search_query", {})
     assert exc.value.status_code == 400

--- a/tests/unit/test_mcp_app.py
+++ b/tests/unit/test_mcp_app.py
@@ -46,7 +46,10 @@ def test_tool_endpoint_envelope():
     assert res.status_code == 200
     out = res.json()
     assert "meta" in out and "traceId" in out["meta"] and "durationMs" in out["meta"]
-    assert out["body"] == {"tool": "echo", "payload": {"hello": "world"}}
+    assert out["body"] == {
+        "ok": True,
+        "data": {"tool": "echo", "payload": {"hello": "world"}},
+    }
     assert out["warnings"] == []
 
 


### PR DESCRIPTION
## Summary
- enforce 10-minute idempotency cache, size limits, timeout and canonical errors in `invoke_tool`
- validate envelope structure for tool endpoints
- add tests for caching, bounds and timeout scenarios

## Testing
- `make fmt`
- `make lint` *(fails: src/langchain/lc_merge_runner.py:143:80: E501 line too long (82 > 79 characters))*
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68c4d60da144832cbd14bd5c4b00f10b