### PR TITLE
Add tests for MCP HTTP and STDIO transports

### DIFF
--- a/README.md
+++ b/README.md
@@ -827,6 +827,28 @@ class Meta(BaseModel):
     traceId: str
 ```
 
+### httpx
+[Documentation](https://www.python-httpx.org/): httpx is a fully featured HTTP client for Python.
+
+**Example Usage**:
+```python
+from httpx import ASGITransport, AsyncClient
+
+transport = ASGITransport(app=app)
+async with AsyncClient(transport=transport, base_url="http://test") as client:
+    await client.get("/")
+```
+
+### AnyIO
+[Documentation](https://anyio.readthedocs.io/): AnyIO provides a unified asynchronous I/O API across event loops.
+
+**Example Usage**:
+```python
+import anyio
+
+process = await anyio.open_process(["python", "-m", "src.tool.mcp_stdio"])
+```
+
 
 ---
 ---

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -19,3 +19,6 @@ faker>=15.0.0        # Generate fake test data
 
 # Coverage reporting
 coverage>=7.0.0
+httpx
+anyio
+pytest-asyncio

--- a/tests/mcp/conftest.py
+++ b/tests/mcp/conftest.py
@@ -1,0 +1,6 @@
+import pytest
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"

--- a/tests/mcp/fixtures/prompt_info.json
+++ b/tests/mcp/fixtures/prompt_info.json
@@ -1,0 +1,5 @@
+{
+  "domain": "writing",
+  "name": "sectioned_draft",
+  "major": "3"
+}

--- a/tests/mcp/fixtures/tool_payload.json
+++ b/tests/mcp/fixtures/tool_payload.json
@@ -1,0 +1,4 @@
+{
+  "tool": "web_search_query",
+  "payload": {"query": "pytest"}
+}

--- a/tests/mcp/test_http_prompts.py
+++ b/tests/mcp/test_http_prompts.py
@@ -1,0 +1,29 @@
+import json
+from pathlib import Path
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+from src.tool.mcp_app import app
+
+
+@pytest.fixture()
+def prompt_info():
+    path = Path(__file__).parent / "fixtures" / "prompt_info.json"
+    return json.loads(path.read_text())
+
+
+@pytest.mark.anyio
+async def test_http_prompt_determinism(prompt_info):
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        results = []
+        for _ in range(2):
+            resp = await client.get(
+                f"/mcp/prompt/{prompt_info['domain']}/{prompt_info['name']}/{prompt_info['major']}"
+            )
+            assert resp.status_code == 200
+            data = resp.json()
+            assert "body" in data and "spec" in data
+            results.append(data)
+        assert results[0] == results[1]

--- a/tests/mcp/test_http_tools.py
+++ b/tests/mcp/test_http_tools.py
@@ -1,0 +1,31 @@
+import json
+from pathlib import Path
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+from src.tool.mcp_app import app
+from src.tool.service import STUB_OUTPUTS
+
+
+@pytest.fixture()
+def tool_payload():
+    path = Path(__file__).parent / "fixtures" / "tool_payload.json"
+    return json.loads(path.read_text())
+
+
+@pytest.mark.anyio
+async def test_http_tool_determinism(tool_payload):
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        bodies = []
+        for _ in range(2):
+            resp = await client.post(
+                f"/mcp/tool/{tool_payload['tool']}", json=tool_payload["payload"]
+            )
+            assert resp.status_code == 200
+            data = resp.json()
+            assert "meta" in data and "body" in data
+            assert data["body"] == STUB_OUTPUTS[tool_payload["tool"]]
+            bodies.append(data["body"])
+        assert bodies[0] == bodies[1]

--- a/tests/mcp/test_stdio_rpc.py
+++ b/tests/mcp/test_stdio_rpc.py
@@ -1,0 +1,52 @@
+import json
+from pathlib import Path
+
+import anyio
+import pytest
+
+from src.tool.service import STUB_OUTPUTS
+
+
+@pytest.fixture()
+def tool_payload():
+    path = Path(__file__).parent / "fixtures" / "tool_payload.json"
+    return json.loads(path.read_text())
+
+
+async def _send_request(process, message):
+    data = json.dumps(message).encode("utf-8")
+    header = f"Content-Length: {len(data)}\r\n\r\n".encode("utf-8")
+    await process.stdin.send(header + data)
+    header_bytes = b""
+    while b"\r\n\r\n" not in header_bytes:
+        header_bytes += await process.stdout.receive(1)
+    headers = header_bytes.decode()
+    content_length = 0
+    for line in headers.split("\r\n"):
+        if line.lower().startswith("content-length:"):
+            content_length = int(line.split(":")[1].strip())
+            break
+    body = b""
+    while len(body) < content_length:
+        body += await process.stdout.receive(content_length - len(body))
+    assert content_length == len(body)
+    return json.loads(body.decode("utf-8"))
+
+
+@pytest.mark.anyio
+async def test_stdio_rpc_tool_determinism(tool_payload):
+    process = await anyio.open_process(["python", "-m", "src.tool.mcp_stdio"])
+    async with process:
+        msg = {
+            "jsonrpc": "2.0",
+            "method": "mcp.tool.invoke",
+            "params": {
+                "tool": tool_payload["tool"],
+                "payload": tool_payload["payload"],
+            },
+            "id": 1,
+        }
+        first = await _send_request(process, msg)
+        msg["id"] = 2
+        second = await _send_request(process, msg)
+        assert first["result"] == second["result"] == STUB_OUTPUTS[tool_payload["tool"]]


### PR DESCRIPTION
## Summary
- add MCP HTTP endpoint tests for tool invocation and prompt retrieval
- cover STDIO JSON-RPC transport with framing and deterministic responses
- document httpx/AnyIO test dependencies

## Testing
- `pytest tests/mcp/test_http_tools.py tests/mcp/test_http_prompts.py tests/mcp/test_stdio_rpc.py -q`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c4d6a58d5c832cabecbd2288d44993