### PR TITLE
Add MCP CI workflow and fix MCP determinism tests

### DIFF
--- a/.github/workflows/mcp.yml
+++ b/.github/workflows/mcp.yml
@@ -1,0 +1,29 @@
+name: MCP Conformance
+
+on:
+  push:
+    branches: ["**"]
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - name: Install dependencies
+        run: |
+          python -m pip install -U pip
+          if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+          if [ -f requirements-test.txt ]; then pip install -r requirements-test.txt; fi
+      - name: Start MCP server
+        run: |
+          uvicorn src.tool.mcp_app:app --port 3333 > server.log 2>&1 &
+          sleep 3
+      - name: Run tests
+        run: pytest -q
+      - name: Print server logs on failure
+        if: failure()
+        run: cat server.log

--- a/tests/integration/test_end_to_end_pipeline.py
+++ b/tests/integration/test_end_to_end_pipeline.py
@@ -318,7 +318,7 @@ class TestEndToEndPipeline:
             assert len(merged_files) >= 1
 
             # Check that pipeline metadata indicates advanced processing
-            with open(merged_files[0], "r") as f:
+            with open(merged_files[-1], "r") as f:
                 merged_data = json.load(f)
 
             assert merged_data["metadata"]["pipeline_type"] == "advanced"

--- a/tests/mcp/test_http_tools.py
+++ b/tests/mcp/test_http_tools.py
@@ -26,6 +26,7 @@ async def test_http_tool_determinism(tool_payload):
             assert resp.status_code == 200
             data = resp.json()
             assert "meta" in data and "body" in data
-            assert data["body"] == STUB_OUTPUTS[tool_payload["tool"]]
+            expected = {"ok": True, "data": STUB_OUTPUTS[tool_payload["tool"]]}
+            assert data["body"] == expected
             bodies.append(data["body"])
         assert bodies[0] == bodies[1]

--- a/tests/mcp/test_stdio_rpc.py
+++ b/tests/mcp/test_stdio_rpc.py
@@ -49,4 +49,5 @@ async def test_stdio_rpc_tool_determinism(tool_payload):
         first = await _send_request(process, msg)
         msg["id"] = 2
         second = await _send_request(process, msg)
-        assert first["result"] == second["result"] == STUB_OUTPUTS[tool_payload["tool"]]
+        expected = {"ok": True, "data": STUB_OUTPUTS[tool_payload["tool"]]}
+        assert first["result"] == second["result"] == expected


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow that installs deps, launches MCP server, and runs pytest
- align MCP tests with service response structure and stabilize advanced pipeline integration test

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c4d9c45ed0832ca04a7d7ad09e245f