### PR TITLE
Validate tool outputs against JSON schemas

### DIFF
--- a/src/tool/schemas.py
+++ b/src/tool/schemas.py
@@ -24,6 +24,13 @@ for path in SCHEMAS_DIR.glob("*.output.schema.json"):
     OUTPUT_VALIDATORS[tool] = Draft7Validator(schema)
 
 
+def validate_tool_input(tool: str, data: Dict[str, Any]) -> None:
+    validator = INPUT_VALIDATORS.get(tool)
+    if validator is None:
+        raise KeyError(f"No input schema for tool: {tool}")
+    validator.validate(data)
+
+
 def validate_tool_output(tool: str, data: Dict[str, Any]) -> None:
     validator = OUTPUT_VALIDATORS.get(tool)
     if validator is None:

--- a/tests/tool/test_tool_schemas.py
+++ b/tests/tool/test_tool_schemas.py
@@ -19,6 +19,20 @@ def test_invoke_tool_schema_violation(monkeypatch):
     assert exc.value.detail["error"] == "schema_validation_failed"
 
 
+def test_invoke_tool_validates_after_runner(monkeypatch):
+    from src.tool import service
+
+    def fake_run_tool(tool, payload):
+        return {}
+
+    monkeypatch.setattr(service, "_run_tool", fake_run_tool)
+    service._CACHE.clear()
+    with pytest.raises(HTTPException) as exc:
+        service.invoke_tool("web_search_query", {})
+    assert exc.value.status_code == 400
+    assert exc.value.detail["error"] == "schema_validation_failed"
+
+
 def test_schemas_compile_and_validate():
     from src.tool import schemas
     import jsonschema


### PR DESCRIPTION
## Summary
- load canonical tool schemas and expose `validate_tool_input`/`validate_tool_output`
- validate `invoke_tool` responses against the output schema after execution
- add regression tests ensuring schema violations raise HTTP 400

## Testing
- `python -m black src/tool/schemas.py src/tool/service.py tests/tool/test_tool_schemas.py`
- `python -m flake8 src/tool/schemas.py src/tool/service.py tests/tool/test_tool_schemas.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c4df05df20832c9f6b654177bb3176