### PR TITLE
feat(toolpacks): support node and http execution

### DIFF
--- a/src/tool/toolpack_models.py
+++ b/src/tool/toolpack_models.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Any, Dict, List, Literal, Optional
 
+
 from pydantic import BaseModel, Field
 
 
@@ -17,10 +18,19 @@ class ToolLimits(BaseModel):
 
 class ToolPack(BaseModel):
     id: str
-    kind: Literal["python", "cli"]
+    kind: Literal["python", "cli", "node", "http"]
     entry: str | List[str]
     schema: ToolSchema
     timeoutMs: Optional[int] = None
     limits: ToolLimits = Field(default_factory=ToolLimits)
     env: List[str] = Field(default_factory=list)
+    headers: Dict[str, str] = Field(default_factory=dict)
+    templating: Optional["Templating"] = None
     deterministic: bool = False
+
+
+class Templating(BaseModel):
+    cacheKey: Optional[str] = None
+
+
+ToolPack.model_rebuild()

--- a/tests/tool/test_toolpack_integration.py
+++ b/tests/tool/test_toolpack_integration.py
@@ -23,3 +23,47 @@ def test_toolpack_invocation_and_schema_validation(monkeypatch):
     monkeypatch.setattr(md, "run", bad_run)
     with pytest.raises(HTTPException):
         service.invoke_tool("markdown", {"text": "bye"})
+
+
+def test_node_toolpack_invocation(monkeypatch):
+    service._CACHE.clear()
+    res = service.invoke_tool("node_echo", {"text": "hi", "prefix": "--"})
+    assert res == {"ok": True, "data": {"echo": "--hi"}}
+
+
+def test_http_toolpack_invocation_templating_and_cache(monkeypatch):
+    service._CACHE.clear()
+    calls = []
+
+    class Resp:
+        def __init__(self, data):
+            self._data = data
+
+        def json(self):
+            return self._data
+
+    def fake_post(url, json, headers, timeout):
+        calls.append((url, json, headers))
+        return Resp({"data": {"echo": json["input"]["text"]}})
+
+    import requests
+
+    monkeypatch.setattr(requests, "post", fake_post)
+
+    payload = {"path": "foo", "token": "abc", "text": "hi"}
+    res1 = service.invoke_tool("http_echo", payload)
+    assert res1 == {"ok": True, "data": {"echo": "hi"}}
+    assert calls[0][0] == "https://example.com/foo"
+    assert calls[0][2]["X-Token"] == "abc"
+
+    payload2 = {"path": "foo", "token": "def", "text": "hi"}
+    res2 = service.invoke_tool("http_echo", payload2)
+    assert res2 == res1
+    assert len(calls) == 1  # cache hit via templating.cacheKey
+
+    def bad_post(url, json, headers, timeout):
+        return Resp({"data": {"oops": "nope"}})
+
+    monkeypatch.setattr(requests, "post", bad_post)
+    with pytest.raises(HTTPException):
+        service.invoke_tool("http_echo", {"path": "bar", "token": "xyz", "text": "hi"})

--- a/tools/example/http_echo.input.schema.json
+++ b/tools/example/http_echo.input.schema.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "properties": {
+    "path": {"type": "string"},
+    "token": {"type": "string"},
+    "text": {"type": "string"}
+  },
+  "required": ["path", "token", "text"]
+}

--- a/tools/example/http_echo.output.schema.json
+++ b/tools/example/http_echo.output.schema.json
@@ -1,0 +1,8 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "properties": {
+    "echo": {"type": "string"}
+  },
+  "required": ["echo"]
+}

--- a/tools/example/http_echo.tool.yaml
+++ b/tools/example/http_echo.tool.yaml
@@ -1,0 +1,14 @@
+id: http_echo
+kind: http
+entry: https://example.com/{{input.path}}
+headers:
+  X-Token: "{{input.token}}"
+deterministic: true
+timeoutMs: 1000
+templating:
+  cacheKey: "{{input.path}}"
+schema:
+  input:
+    $ref: ./http_echo.input.schema.json
+  output:
+    $ref: ./http_echo.output.schema.json

--- a/tools/example/node_echo.input.schema.json
+++ b/tools/example/node_echo.input.schema.json
@@ -1,0 +1,9 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "properties": {
+    "text": {"type": "string"},
+    "prefix": {"type": "string"}
+  },
+  "required": ["text", "prefix"]
+}

--- a/tools/example/node_echo.mjs
+++ b/tools/example/node_echo.mjs
@@ -1,0 +1,13 @@
+#!/usr/bin/env node
+import fs from 'fs';
+
+const args = process.argv.slice(2);
+const prefix = args[0] || '';
+
+let input = '';
+for await (const chunk of process.stdin) {
+  input += chunk;
+}
+const data = JSON.parse(input);
+const out = { echo: `${prefix}${data.text}` };
+process.stdout.write(JSON.stringify(out));

--- a/tools/example/node_echo.output.schema.json
+++ b/tools/example/node_echo.output.schema.json
@@ -1,0 +1,8 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "properties": {
+    "echo": {"type": "string"}
+  },
+  "required": ["echo"]
+}

--- a/tools/example/node_echo.tool.yaml
+++ b/tools/example/node_echo.tool.yaml
@@ -1,0 +1,16 @@
+id: node_echo
+kind: node
+entry:
+  - tools/example/node_echo.mjs
+  - "{{input.prefix}}"
+deterministic: true
+timeoutMs: 1000
+limits:
+  input: 4096
+  output: 4096
+env: []
+schema:
+  input:
+    $ref: ./node_echo.input.schema.json
+  output:
+    $ref: ./node_echo.output.schema.json


### PR DESCRIPTION
## Summary
- add `node` and `http` execution kinds with templated argv, URL and headers
- allow toolpacks to override caching via `templating.cacheKey`
- document and test new node and http tool examples

## Testing
- `ruff check --fix .` *(fails: 198 errors, 121 fixed, 77 remaining)*
- `black src/tool/executor.py src/tool/service.py src/tool/toolpack_models.py tests/tool/test_toolpack_integration.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68c4eb9dc7d8832c82b505c75d83ed21