### PR TITLE
Add PHP toolpack support

### DIFF
--- a/README.md
+++ b/README.md
@@ -735,10 +735,10 @@ Model Context Protocol contracts.
 
 Additional tools can be declared by dropping `*.tool.yaml` files under the
 `tools/` directory. Each YAML file defines a *toolpack* with an `id`, `kind`
-(`python`, `cli`, `node`, or `http`), an entry point, and JSON schemas for input
-and output. On startup these files are loaded and exposed over `/mcp/tool/<id>`.
-Jinja2 templating is supported for argv, URL, and headers, and a
-`templating.cacheKey` value can override caching behavior.
+(`python`, `cli`, `node`, `php`, or `http`), an entry point (or `php` script
+path), and JSON schemas for input and output. On startup these files are loaded
+and exposed over `/mcp/tool/<id>`. Jinja2 templating is supported for argv, URL,
+and headers, and a `templating.cacheKey` value can override caching behavior.
 
 ### Multi-agent CLI
 
@@ -790,8 +790,10 @@ Pydantic models describing YAML-defined toolpacks.
 
 #### `class ToolPack(BaseModel)`
 - `id: str` – canonical tool identifier
-- `kind: Literal['python','cli','node','http']`
-- `entry: str | List[str]` – module path, CLI/Node argv, or HTTP URL
+- `kind: Literal['python','cli','node','http','php']`
+- `entry: str | List[str] | None` – module path, CLI/Node argv, or HTTP URL
+- `php: str | List[str] | None` – PHP script path
+- `phpBinary: Optional[str]` – PHP interpreter override
 - `schema: ToolSchema` – input and output JSON schemas
 - `timeoutMs: Optional[int]`
 - `limits: ToolLimits` – input/output byte caps

--- a/src/tool/executor.py
+++ b/src/tool/executor.py
@@ -78,6 +78,14 @@ def run_toolpack(tp: ToolPack, payload: Dict[str, Any]) -> Dict[str, Any]:
         else:
             cmd = ["node", _render_template(tp.entry, payload)]
         return _run_subprocess(cmd, payload, env, timeout)
+    if tp.kind == "php":
+        entry = tp.php if tp.php is not None else tp.entry
+        php_bin = tp.phpBinary or "php"
+        if isinstance(entry, list):
+            cmd = [php_bin] + _render_list(entry, payload)
+        else:
+            cmd = [php_bin, _render_template(entry, payload)]
+        return _run_subprocess(cmd, payload, env, timeout)
     # http
     url = _render_template(tp.entry, payload)
     headers = {k: _render_template(v, payload) for k, v in tp.headers.items()}

--- a/src/tool/toolpack_models.py
+++ b/src/tool/toolpack_models.py
@@ -18,8 +18,10 @@ class ToolLimits(BaseModel):
 
 class ToolPack(BaseModel):
     id: str
-    kind: Literal["python", "cli", "node", "http"]
-    entry: str | List[str]
+    kind: Literal["python", "cli", "node", "http", "php"]
+    entry: str | List[str] | None = None
+    php: str | List[str] | None = None
+    phpBinary: Optional[str] = None
     schema: ToolSchema
     timeoutMs: Optional[int] = None
     limits: ToolLimits = Field(default_factory=ToolLimits)

--- a/tests/mcp/test_php_tools.py
+++ b/tests/mcp/test_php_tools.py
@@ -1,0 +1,59 @@
+import json
+import subprocess
+import sys
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+from src.tool.mcp_app import app
+
+
+def _send(proc, msg):
+    data = json.dumps(msg).encode()
+    frame = f"Content-Length: {len(data)}\r\n\r\n".encode() + data
+    proc.stdin.write(frame)
+    proc.stdin.flush()
+    header = {}
+    while True:
+        line = proc.stdout.readline()
+        if line == b"":
+            raise RuntimeError("no response")
+        if line == b"\r\n":
+            break
+        if line.lower().startswith(b"content-length:"):
+            header["length"] = int(line.split(b":")[1].strip())
+    body = proc.stdout.read(header["length"])
+    return json.loads(body.decode())
+
+
+@pytest.mark.anyio
+async def test_http_php_tool():
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        resp = await client.post("/mcp/tool/util.php.echo", json={"message": "hello"})
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["body"] == {"ok": True, "data": {"echo": "hello"}}
+
+
+def test_stdio_php_tool():
+    proc = subprocess.Popen(
+        [sys.executable, "-m", "src.tool.mcp_stdio"],
+        stdin=subprocess.PIPE,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    try:
+        resp = _send(
+            proc,
+            {
+                "jsonrpc": "2.0",
+                "id": 1,
+                "method": "mcp.tool.invoke",
+                "params": {"tool": "util.php.echo", "payload": {"message": "hello"}},
+            },
+        )
+        assert resp["result"] == {"ok": True, "data": {"echo": "hello"}}
+    finally:
+        proc.terminate()
+        proc.wait(timeout=3)

--- a/tools/example/php_echo.input.schema.json
+++ b/tools/example/php_echo.input.schema.json
@@ -1,0 +1,8 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "properties": {
+    "message": {"type": "string"}
+  },
+  "required": ["message"]
+}

--- a/tools/example/php_echo.output.schema.json
+++ b/tools/example/php_echo.output.schema.json
@@ -1,0 +1,8 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "properties": {
+    "echo": {"type": "string"}
+  },
+  "required": ["echo"]
+}

--- a/tools/example/php_echo.php
+++ b/tools/example/php_echo.php
@@ -1,0 +1,7 @@
+#!/usr/bin/env php
+<?php
+$input = stream_get_contents(STDIN);
+$data = json_decode($input, true);
+$out = ["echo" => $data["message"] ?? null];
+echo json_encode($out);
+?>

--- a/tools/example/php_echo.tool.yaml
+++ b/tools/example/php_echo.tool.yaml
@@ -1,0 +1,14 @@
+id: util.php.echo
+kind: php
+php: tools/example/php_echo.php
+deterministic: true
+timeoutMs: 1000
+limits:
+  input: 4096
+  output: 4096
+env: []
+schema:
+  input:
+    $ref: ./php_echo.input.schema.json
+  output:
+    $ref: ./php_echo.output.schema.json


### PR DESCRIPTION
## Summary
- extend toolpack schema and executor to run PHP CLI scripts
- add example `php_echo` tool and schemas
- document PHP toolpacks in README and test HTTP/STDIO invocation

## Testing
- `pytest tests/mcp/test_php_tools.py::test_http_php_tool -q`
- `pytest tests/mcp/test_php_tools.py::test_stdio_php_tool -q`
- `make fmt lint test` *(fails: tests/unit/test_outline_converter.py:304:80: E501 line too long (89 > 79 characters))*
- `make test` *(fails: tests/unit/test_tool_interface.py::test_mcp_tool_registration_and_invocation - Failed: async def functions are not natively awaitable)*

------
https://chatgpt.com/codex/tasks/task_e_68c4f2a1984c832c850eeb5db571d6cf