### PR TITLE
feat: expand MCP discovery metadata

### DIFF
--- a/tests/tool/test_mcp_stdio.py
+++ b/tests/tool/test_mcp_stdio.py
@@ -30,7 +30,7 @@ def test_stdio_discover_and_invoke():
     )
     try:
         resp1 = _send(proc, {"jsonrpc": "2.0", "id": 1, "method": "mcp.discover"})
-        assert resp1["result"]["mcp"] == "stub"
+        assert resp1["result"]["server"]["name"] == "rag-writer"
         resp2 = _send(
             proc,
             {

--- a/tests/tool/test_toolpack_integration.py
+++ b/tests/tool/test_toolpack_integration.py
@@ -7,7 +7,8 @@ from src.tool import service
 def test_toolpack_discovery_includes_example():
     info = service.discover()
     assert "tools" in info
-    assert "markdown" in info["tools"]
+    names = [t["name"] for t in info["tools"]]
+    assert "markdown" in names
 
 
 def test_toolpack_invocation_and_schema_validation(monkeypatch):


### PR DESCRIPTION
## Summary
- expand MCP discovery output with server, tools, prompts, and health metadata
- include tool schema refs and capability limits for each toolpack
- validate discovery and stdio RPC via updated tests

## Testing
- `make fmt`
- `make lint` (fails: E501 line too long, F401 unused imports, etc.)
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c5093316b8832cbc043b3b2cf3d023