### PR TITLE
Enable optional GPU acceleration for FAISS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,8 @@ PY_CMD := $(shell command -v python3.11 || command -v python3.10 || command -v p
 PY := python
 #PIP := $(ROOT)/venv/bin/pip
 PIP := pip
+# FAISS backend selector (cpu or gpu)
+FAISS_BACKEND ?= cpu
 # Docker
 DOCKER_IMAGE ?= rag-writer:latest
 
@@ -67,7 +69,13 @@ init:
 	mkdir -p $(ROOT)/data_raw $(ROOT)/data_processed $(ROOT)/storage/lancedb_default $(ROOT)/storage/faiss_default $(ROOT)/src/llamaindex $(ROOT)/src/langchain $(ROOT)/src/tool $(ROOT)/src/config/content/prompts
 	$(PY_CMD) -m venv $(ROOT)/venv
 	$(PIP) install -U pip wheel setuptools
-	$(PIP) install -r $(ROOT)/requirements.txt
+        $(PIP) install -r $(ROOT)/requirements.txt
+        if [ -f "$(ROOT)/requirements-faiss-$(FAISS_BACKEND).txt" ]; then \
+                $(PIP) install -r $(ROOT)/requirements-faiss-$(FAISS_BACKEND).txt; \
+        else \
+                echo "Unknown FAISS_BACKEND=$(FAISS_BACKEND); expected cpu or gpu"; \
+                exit 1; \
+        fi
 	@echo "Init complete. Put PDFs into $(ROOT)/data_raw/"
 
 # ----- LangChain -----

--- a/README.md
+++ b/README.md
@@ -47,7 +47,8 @@ This suite provides a complete workflow for content creation and processing usin
 
 ```bash
 #### Install Python dependencies globally
-pip install -r requirements.txt
+pip install -r requirements.txt -r requirements-faiss-cpu.txt
+# or swap requirements-faiss-cpu.txt for requirements-faiss-gpu.txt on CUDA hosts
 pip install -r requirements-test.txt
 ```
 
@@ -55,7 +56,8 @@ pip install -r requirements-test.txt
 ```bash
 python -m venv venv
 source venv/bin/activate
-pip install -r requirements.txt
+pip install -r requirements.txt -r requirements-faiss-cpu.txt
+# or swap requirements-faiss-cpu.txt for requirements-faiss-gpu.txt on CUDA hosts
 pip install -r requirements-test.txt
 
 ```
@@ -91,6 +93,8 @@ sops -e env.json > env.json
 ```bash
 # Complete setup and workflow
 make init                # Set up environment
+# (optional) make init with GPU FAISS wheel
+FAISS_BACKEND=gpu make init
 make lc-index KEY=default  # Build FAISS index
 make cli-ask "What is machine learning?"  # Ask questions via Typer CLI
 make cli-shell           # Interactive shell
@@ -140,6 +144,7 @@ make examples      # List all available example files
 #### Core CLI Targets
 ```bash
 make init                                # Initialize environment and install dependencies
+FAISS_BACKEND=gpu make init              # Same as above but installs faiss-gpu
 make lc-index KEY=foo SHARD_SIZE=2000 RESUME=1  # Build sharded FAISS index
 make cli-ask "question"                  # RAG query via Typer CLI
 make cli-shell                           # Interactive shell

--- a/requirements-faiss-cpu.txt
+++ b/requirements-faiss-cpu.txt
@@ -1,0 +1,2 @@
+# Default FAISS backend for CPU-only environments
+faiss-cpu>=1.8.0

--- a/requirements-faiss-gpu.txt
+++ b/requirements-faiss-gpu.txt
@@ -1,0 +1,2 @@
+# Optional FAISS backend with CUDA support
+faiss-gpu>=1.8.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,7 +19,9 @@ langchain-text-splitters>=0.2.2,<0.3
 
 # Vector stores
 lancedb>=0.6,<=0.13
-faiss-cpu>=1.8.0
+# Select a FAISS backend by installing one of the overlay files:
+#   pip install -r requirements.txt -r requirements-faiss-cpu.txt   # default
+#   pip install -r requirements.txt -r requirements-faiss-gpu.txt   # CUDA
 
 # Retrieval helpers
 rank_bm25>=0.2.2

--- a/src/core/faiss_utils.py
+++ b/src/core/faiss_utils.py
@@ -1,0 +1,57 @@
+"""Helpers for working with FAISS on optional GPU hardware."""
+
+from __future__ import annotations
+
+import importlib
+from typing import Any, Optional
+
+
+def _import_faiss() -> Optional[Any]:
+    """Return the imported ``faiss`` module or ``None`` if unavailable."""
+    try:
+        return importlib.import_module("faiss")
+    except ModuleNotFoundError:
+        return None
+
+
+def _gpu_runtime_available(faiss_module: Any) -> bool:
+    required_attrs = ["index_cpu_to_all_gpus", "index_gpu_to_cpu", "StandardGpuResources"]
+    if not all(hasattr(faiss_module, attr) for attr in required_attrs):
+        return False
+    get_num_gpus = getattr(faiss_module, "get_num_gpus", None)
+    if get_num_gpus is None:
+        return False
+    try:
+        return bool(get_num_gpus())
+    except Exception:
+        return False
+
+
+def is_faiss_gpu_available() -> bool:
+    """Return ``True`` if FAISS GPU bindings are importable and GPUs are visible."""
+    faiss_module = _import_faiss()
+    if faiss_module is None:
+        return False
+    return _gpu_runtime_available(faiss_module)
+
+
+def clone_index_to_gpu(index: Any) -> Optional[Any]:
+    """Clone a CPU index to GPU memory when supported."""
+    faiss_module = _import_faiss()
+    if faiss_module is None or not _gpu_runtime_available(faiss_module):
+        return None
+    try:
+        return faiss_module.index_cpu_to_all_gpus(index)
+    except Exception:
+        return None
+
+
+def clone_index_to_cpu(index: Any) -> Any:
+    """Return a CPU copy of a FAISS index, even if the input lives on GPU."""
+    faiss_module = _import_faiss()
+    if faiss_module is None or not hasattr(faiss_module, "index_gpu_to_cpu"):
+        return index
+    try:
+        return faiss_module.index_gpu_to_cpu(index)
+    except Exception:
+        return index

--- a/tests/langchain/test_lc_build_index_gpu.py
+++ b/tests/langchain/test_lc_build_index_gpu.py
@@ -1,0 +1,126 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+from langchain_core.documents import Document
+
+from src.langchain import lc_build_index
+
+
+class DummyIndex:
+    def __init__(self, name: str):
+        self.name = name
+        self.merged = []
+
+    def merge_from(self, other: "DummyIndex") -> None:
+        self.merged.append(other.name)
+
+
+class DummyVectorStore:
+    saved_paths: list[Path] = []
+    shard_counter = 0
+
+    def __init__(self, name: str):
+        self.name = name
+        self.index = DummyIndex(name)
+
+    @classmethod
+    def from_texts(cls, texts: list[str], embedding: Any, metadatas: list[dict]) -> "DummyVectorStore":
+        inst = cls(f"shard-{cls.shard_counter}")
+        cls.shard_counter += 1
+        return inst
+
+    def save_local(self, folder_path: str) -> None:
+        path = Path(folder_path)
+        path.mkdir(parents=True, exist_ok=True)
+        self.saved_paths.append(path)
+
+    @classmethod
+    def load_local(
+        cls,
+        folder_path: str,
+        embeddings: Any,
+        allow_dangerous_deserialization: bool = True,
+    ) -> "DummyVectorStore":
+        # Each shard is reloaded with a new instance whose name is derived from the folder
+        name = Path(folder_path).name
+        return cls(name)
+
+    def merge_from(self, other: "DummyVectorStore") -> None:
+        self.index.merge_from(other.index)
+
+
+class DummyEmbeddings:
+    def __init__(self, model_name: str) -> None:
+        self.model_name = model_name
+
+
+def _make_docs(count: int) -> list[Document]:
+    return [Document(page_content=f"doc {i}", metadata={"i": i}) for i in range(count)]
+
+
+def test_build_promotes_indexes_to_gpu(monkeypatch, tmp_path):
+    docs = _make_docs(4)
+
+    gpu_indices = []
+    cpu_indices = []
+    DummyVectorStore.saved_paths.clear()
+    DummyVectorStore.shard_counter = 0
+
+    monkeypatch.setattr(lc_build_index, "HuggingFaceEmbeddings", DummyEmbeddings)
+    monkeypatch.setattr(lc_build_index, "FAISS", DummyVectorStore)
+    monkeypatch.setattr(lc_build_index.faiss_utils, "is_faiss_gpu_available", lambda: True)
+
+    def fake_clone_gpu(index: DummyIndex) -> DummyIndex:
+        gpu_index = DummyIndex(f"gpu-{index.name}")
+        gpu_indices.append(gpu_index.name)
+        return gpu_index
+
+    def fake_clone_cpu(index: DummyIndex) -> DummyIndex:
+        cpu_indices.append(index.name)
+        return DummyIndex(f"cpu-{index.name}")
+
+    monkeypatch.setattr(lc_build_index.faiss_utils, "clone_index_to_gpu", fake_clone_gpu)
+    monkeypatch.setattr(lc_build_index.faiss_utils, "clone_index_to_cpu", fake_clone_cpu)
+    monkeypatch.chdir(tmp_path)
+
+    lc_build_index.build_faiss_for_models(
+        docs,
+        key="demo",
+        embedding_models=["model"],
+        shard_size=2,
+        resume=False,
+        keep_shards=True,
+    )
+
+    # Two shards are merged, so GPU promotion should have been attempted at least twice
+    assert len(gpu_indices) >= 2
+    # Before saving, the GPU index should be converted back to CPU once
+    assert cpu_indices and all(name.startswith("gpu-") for name in cpu_indices)
+
+
+def test_build_skips_gpu_when_unavailable(monkeypatch, tmp_path):
+    docs = _make_docs(2)
+
+    DummyVectorStore.saved_paths.clear()
+    DummyVectorStore.shard_counter = 0
+    monkeypatch.setattr(lc_build_index, "HuggingFaceEmbeddings", DummyEmbeddings)
+    monkeypatch.setattr(lc_build_index, "FAISS", DummyVectorStore)
+    monkeypatch.setattr(lc_build_index.faiss_utils, "is_faiss_gpu_available", lambda: False)
+
+    def fail_clone(_: DummyIndex) -> DummyIndex:  # pragma: no cover - should not be hit
+        raise AssertionError("GPU clone should not be attempted when unavailable")
+
+    monkeypatch.setattr(lc_build_index.faiss_utils, "clone_index_to_gpu", fail_clone)
+    monkeypatch.setattr(lc_build_index.faiss_utils, "clone_index_to_cpu", fail_clone)
+    monkeypatch.chdir(tmp_path)
+
+    lc_build_index.build_faiss_for_models(
+        docs,
+        key="demo",
+        embedding_models=["model"],
+        shard_size=2,
+        resume=False,
+        keep_shards=True,
+    )

--- a/tests/unit/test_faiss_utils.py
+++ b/tests/unit/test_faiss_utils.py
@@ -1,0 +1,56 @@
+import importlib
+import sys
+from types import SimpleNamespace
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def cleanup_faiss_module(monkeypatch):
+    original = sys.modules.get("faiss")
+    yield
+    if "faiss" in sys.modules:
+        del sys.modules["faiss"]
+    if original is not None:
+        sys.modules["faiss"] = original
+
+
+def test_is_faiss_gpu_available_false_when_module_missing(monkeypatch):
+    monkeypatch.delitem(sys.modules, "faiss", raising=False)
+    faiss_utils = importlib.import_module("src.core.faiss_utils")
+    importlib.reload(faiss_utils)
+
+    assert faiss_utils.is_faiss_gpu_available() is False
+
+
+def test_is_faiss_gpu_available_true_when_functions_present(monkeypatch):
+    fake_faiss = SimpleNamespace(
+        StandardGpuResources=object,
+        index_cpu_to_all_gpus=lambda index: f"gpu:{index}",
+        index_gpu_to_cpu=lambda index: f"cpu:{index}",
+        get_num_gpus=lambda: 2,
+    )
+    monkeypatch.setitem(sys.modules, "faiss", fake_faiss)
+    faiss_utils = importlib.import_module("src.core.faiss_utils")
+    importlib.reload(faiss_utils)
+
+    assert faiss_utils.is_faiss_gpu_available() is True
+
+    gpu_index = faiss_utils.clone_index_to_gpu("idx")
+    assert gpu_index == "gpu:idx"
+
+    cpu_index = faiss_utils.clone_index_to_cpu(gpu_index)
+    assert cpu_index == "cpu:gpu:idx"
+
+
+def test_clone_index_to_gpu_returns_none_when_unavailable(monkeypatch):
+    fake_faiss = SimpleNamespace(get_num_gpus=lambda: 0)
+    monkeypatch.setitem(sys.modules, "faiss", fake_faiss)
+    faiss_utils = importlib.import_module("src.core.faiss_utils")
+    importlib.reload(faiss_utils)
+
+    assert faiss_utils.is_faiss_gpu_available() is False
+    assert faiss_utils.clone_index_to_gpu("idx") is None
+
+    # Without GPU helpers, clone_index_to_cpu should return the input unchanged
+    assert faiss_utils.clone_index_to_cpu("idx") == "idx"

--- a/tests/unit/test_retriever_gpu.py
+++ b/tests/unit/test_retriever_gpu.py
@@ -1,0 +1,54 @@
+from types import SimpleNamespace
+
+from src.core import retriever
+
+
+class DummyVectorStore:
+    def __init__(self) -> None:
+        self.index = SimpleNamespace(name="cpu-index")
+
+
+class DummyFAISS:
+    @staticmethod
+    def load_local(path: str, embeddings, allow_dangerous_deserialization: bool = True):
+        return DummyVectorStore()
+
+
+class DummyEmbeddings:
+    pass
+
+
+def test_retriever_promotes_index_to_gpu(monkeypatch, tmp_path):
+    factory = retriever.RetrieverFactory(root_dir=tmp_path)
+
+    monkeypatch.setattr(retriever, "FAISS", DummyFAISS)
+    monkeypatch.setattr(retriever.faiss_utils, "is_faiss_gpu_available", lambda: True)
+
+    gpu_calls = []
+
+    def fake_clone_gpu(index):
+        gpu_calls.append(index.name)
+        return SimpleNamespace(name=f"gpu-{index.name}")
+
+    monkeypatch.setattr(retriever.faiss_utils, "clone_index_to_gpu", fake_clone_gpu)
+    embeddings = DummyEmbeddings()
+
+    vectorstore = factory._load_faiss_index(tmp_path, embeddings)
+    assert vectorstore.index.name == "gpu-cpu-index"
+    assert gpu_calls == ["cpu-index"]
+
+
+def test_retriever_stays_on_cpu_without_gpu(monkeypatch, tmp_path):
+    factory = retriever.RetrieverFactory(root_dir=tmp_path)
+
+    monkeypatch.setattr(retriever, "FAISS", DummyFAISS)
+    monkeypatch.setattr(retriever.faiss_utils, "is_faiss_gpu_available", lambda: False)
+
+    def fail_clone(index):  # pragma: no cover - should never run
+        raise AssertionError("GPU clone should not execute when unavailable")
+
+    monkeypatch.setattr(retriever.faiss_utils, "clone_index_to_gpu", fail_clone)
+    embeddings = DummyEmbeddings()
+
+    vectorstore = factory._load_faiss_index(tmp_path, embeddings)
+    assert vectorstore.index.name == "cpu-index"


### PR DESCRIPTION
## Summary
- add a shared faiss_utils helper to detect GPU support and convert indexes between CPU and GPU backends
- promote FAISS shards and loaded indexes onto GPU memory when CUDA is available while keeping CPU fallbacks and persistence paths unchanged
- make the FAISS wheel selectable via new requirements overlays, Makefile support, and documentation updates; add unit coverage for GPU and CPU paths

## Testing
- pytest tests/unit/test_faiss_utils.py tests/langchain/test_lc_build_index_gpu.py tests/unit/test_retriever_gpu.py

------
https://chatgpt.com/codex/tasks/task_e_68ccd4461260832c89b147e0a75fe9c0