### PR TITLE
Add config-driven parallel worker default and documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -248,7 +248,7 @@ make lc-ask INSTR="Explain neural networks" TASK="Write for beginners" KEY="scie
 **Options:**
 - `--key`: string specifying the faiss index to query
 - `--k`: number of results to return from vector database
-- `--parallel`: number of parallel workers (default: `1`)
+- `--parallel`: number of parallel workers (default: derived from `RAG_PARALLEL_WORKERS` or clamped `os.cpu_count()`)
 - `--output-dir`: specify output directory
 - `--jobs`: JSON or JSONL file containing job definitions
 
@@ -783,11 +783,24 @@ args = parser.parse_args()
 ```
 
 ### Python Magic
-[Documentation](https://pypi.org/project/python-magic/): python-magic is a Python interface to the libmagic file type identification library. libmagic identifies file types by checking their headers according to a predefined list of file types. This functionality is exposed to the command line by the Unix command file. 
+[Documentation](https://pypi.org/project/python-magic/): python-magic is a Python interface to the libmagic file type identification library. libmagic identifies file types by checking their headers according to a predefined list of file types. This functionality is exposed to the command line by the Unix command file.
 **Example Usage**:
 ```python
 # returns a value such as image/png, application/pdf, text/html
 mime_type = magic.from_file(filepath, mime=True)
+```
+
+### pytest-asyncio
+[Documentation](https://pytest-asyncio.readthedocs.io/en/latest/): pytest-asyncio provides asyncio awareness for pytest so asynchronous tests can run alongside synchronous suites.
+
+**Example Usage**:
+```python
+from src.tool import ToolRegistry
+
+@pytest.mark.asyncio
+async def test_tool_invocation():
+    registry = ToolRegistry()
+    await registry.register_mcp_server("dummy://server")
 ```
 
 
@@ -810,6 +823,7 @@ mime_type = magic.from_file(filepath, mime=True)
 | `OPENAI_MODEL` | Override OpenAI chat model | 📖 | gpt-4o-mini |
 | `OLLAMA_MODEL` | Override local Ollama model | 📖 | llama3.1:8b |
 | `DEBUG` |  Set to 1/true to enable debug mode in config | 📖 | `0/False` |
+| `RAG_PARALLEL_WORKERS` | Default parallel workers for `lc_batch` (see `src/config/settings.py`, `src/langchain/lc_batch.py`) | 📖 | Auto (clamped `os.cpu_count()` to 1-32) |
 
 use `sops-edit env.json` to add/edit new environment variables... append `_pt` (for plaintext) to names of non-secret values. Load sops values into environment using `eval(make sops-env-export) or ``make sops-env-export`` ` operation as this handles removing the suffix and loading them properly 
 
@@ -1560,7 +1574,7 @@ python src/langchain/lc_merge_runner.py --sub 1A1
 
 ### Performance Optimization
 
-- Use `--parallel` in batch processing for faster execution
+- Use `--parallel` in batch processing for faster execution (defaults driven by `RAG_PARALLEL_WORKERS` or CPU count)
 - Adjust `similarity_threshold` in pipeline config for different de-duplication levels
 - Configure appropriate `top_n_variations` based on content complexity
 

--- a/docs/rag-writer.1
+++ b/docs/rag-writer.1
@@ -205,7 +205,7 @@ JSONL file with jobs (required)
 Output directory
 .TP
 .B \-\-parallel \fINUM\fR
-Number of parallel processes (default: 1)
+Number of parallel processes (default: RAG_PARALLEL_WORKERS or clamped os.cpu_count())
 .TP
 .B \-\-key \fIKEY\fR
 Collection key for RAG (default: default)

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -4,6 +4,7 @@ pytest-cov>=4.0.0
 pytest-mock>=3.10.0
 pytest-xdist>=3.0.0  # For parallel test execution
 pytest-html>=3.1.0   # For HTML test reports
+pytest-asyncio>=1.0.0  # Async test support
 
 # Mocking and fixtures
 responses>=0.23.0    # For mocking HTTP requests

--- a/src/langchain/lc_batch.py
+++ b/src/langchain/lc_batch.py
@@ -452,8 +452,11 @@ def main():
     ap.add_argument(
         "--parallel",
         type=int,
-        default=1,
-        help="Number of parallel workers (1 = sequential)",
+        default=config.parallel_workers,
+        help=(
+            "Number of parallel workers (1 = sequential, "
+            f"default: {config.parallel_workers})"
+        ),
     )
     ap.add_argument("--output-dir", help="Custom output directory")
 


### PR DESCRIPTION
## Summary
- add a `parallel_workers` value to the central AppConfig that honors `RAG_PARALLEL_WORKERS` and clamps cpu-based fallbacks
- use the config-driven default when parsing `lc_batch` CLI arguments and cover the behaviour with new integration tests
- document the new environment variable, update CLI/manpage help, and record the pytest-asyncio dependency

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68ccebf1139c832cba39fdcc9de70af0