### PR TITLE
Improve lc_build_index device handling and FAISS utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -327,19 +327,21 @@ make lc-batch FILE="examples/sample_jobs_1A1.jsonl" KEY="biology" PARALLEL=4
 - Multiple data sources
 
 **Options:**
-- `--shard-size`: number of chunks per shard (default:`1000`)
-- `--resume`: Skip shards already built (default: `False`)
-- `--keep-shards`: Do not delete shard directories after merge (default: `False`)
-- `<argument>`:  string specifying the faiss index to query (same as key in other operations)
+- `key`: Positional storage key prefix (defaults to `$RAG_KEY` or `default`)
+- `--shard-size`: Number of chunks per shard (default: `1000`)
+- `--resume [VALUE]`: Skip shards already built (accepts optional value for compatibility)
+- `--keep-shards`: Do not delete shard directories after merge
+- `--no-gpu`: Force embeddings to run on CPU even if accelerators are available
+- `--serve-gpu`: After saving, copy the in-memory FAISS index to GPU for serving
+- `--faiss-threads`: Override FAISS build thread count (default: host CPU count)
 
 **Usage**:
 ```bash
+# Build index using the default key with GPU embeddings when available
+python src/langchain/lc_build_index.py science
 
-#simple
-python src/langchain/lc_build_index.py --source data/ --index my_index
-
-#specify shard size of 200, check for existing shards and resume a previously unfinished index operation, and do not delete shards after merge
-python src/langchain/lc_build_index.py --source data/ --index --resume --shard_size 200 --key_shards my_index
+# Resume a sharded build, keep intermediate shards, pin to CPU, and serve from GPU memory
+python src/langchain/lc_build_index.py science --shard-size 200 --resume --keep-shards --no-gpu --serve-gpu --faiss-threads 8
 
 ```
 

--- a/docs/rag-writer.1
+++ b/docs/rag-writer.1
@@ -458,6 +458,26 @@ docker run --rm -it \
   -v "$PWD":/app \
   -e RAG_KEY=science \
   rag-writer:latest python src/langchain/lc_build_index.py
+.fi
+.SS lc_build_index.py Options
+.PP
+The index builder CLI supports the following arguments:
+.IP \[bu] 2
+\fIkey\fP — storage key prefix (defaults to \fIRAG_KEY\fP or \fIdefault\fP)
+.IP \[bu] 2
+\fB--shard-size\fP \fIN\fP — number of chunks per shard (default 1000)
+.IP \[bu] 2
+\fB--resume\fP [\fIVALUE\fP] — resume shard processing when previous output exists
+.IP \[bu] 2
+\fB--keep-shards\fP — preserve shard directories after merging
+.IP \[bu] 2
+\fB--no-gpu\fP — force embedding to run on CPU even if accelerators are detected
+.IP \[bu] 2
+\fB--serve-gpu\fP — after saving, copy the in-memory FAISS index to GPU for serving
+.IP \[bu] 2
+\fB--faiss-threads\fP \fIN\fP — override FAISS thread count (defaults to host CPU count)
+.sp
+.nf
 
 # Ask a question using the Typer CLI
 docker run --rm -it \

--- a/src/core/faiss_utils.py
+++ b/src/core/faiss_utils.py
@@ -8,6 +8,7 @@ from typing import Any, Optional
 
 def _import_faiss() -> Optional[Any]:
     """Return the imported ``faiss`` module or ``None`` if unavailable."""
+
     try:
         return importlib.import_module("faiss")
     except ModuleNotFoundError:
@@ -29,29 +30,75 @@ def _gpu_runtime_available(faiss_module: Any) -> bool:
 
 def is_faiss_gpu_available() -> bool:
     """Return ``True`` if FAISS GPU bindings are importable and GPUs are visible."""
+
     faiss_module = _import_faiss()
     if faiss_module is None:
         return False
     return _gpu_runtime_available(faiss_module)
 
 
-def clone_index_to_gpu(index: Any) -> Optional[Any]:
-    """Clone a CPU index to GPU memory when supported."""
+def set_faiss_threads(num_threads: int) -> None:
+    """Attempt to configure FAISS threading."""
+
+    if num_threads <= 0:
+        return
+
+    faiss_module = _import_faiss()
+    if faiss_module is None:
+        return
+
+    for attr in ("omp_set_num_threads", "set_num_threads"):
+        setter = getattr(faiss_module, attr, None)
+        if setter is None:
+            continue
+        try:
+            setter(num_threads)
+            return
+        except Exception:
+            continue
+
+
+def ensure_cpu_index(index: Any) -> Any:
+    """Return a CPU copy of ``index`` even if it already lives on GPU."""
+
+    faiss_module = _import_faiss()
+    if faiss_module is None:
+        return index
+
+    to_cpu = getattr(faiss_module, "index_gpu_to_cpu", None)
+    if to_cpu is None:
+        return index
+
+    try:
+        return to_cpu(index)
+    except Exception:
+        return index
+
+
+def try_index_cpu_to_gpu(index: Any) -> Optional[Any]:
+    """Attempt to copy a CPU index to GPU memory."""
+
     faiss_module = _import_faiss()
     if faiss_module is None or not _gpu_runtime_available(faiss_module):
         return None
+
+    to_gpu = getattr(faiss_module, "index_cpu_to_all_gpus", None)
+    if to_gpu is None:
+        return None
+
     try:
-        return faiss_module.index_cpu_to_all_gpus(index)
+        return to_gpu(index)
     except Exception:
         return None
 
 
+def clone_index_to_gpu(index: Any) -> Optional[Any]:
+    """Backward-compatible wrapper for ``try_index_cpu_to_gpu``."""
+
+    return try_index_cpu_to_gpu(index)
+
+
 def clone_index_to_cpu(index: Any) -> Any:
-    """Return a CPU copy of a FAISS index, even if the input lives on GPU."""
-    faiss_module = _import_faiss()
-    if faiss_module is None or not hasattr(faiss_module, "index_gpu_to_cpu"):
-        return index
-    try:
-        return faiss_module.index_gpu_to_cpu(index)
-    except Exception:
-        return index
+    """Backward-compatible wrapper for ``ensure_cpu_index``."""
+
+    return ensure_cpu_index(index)

--- a/tests/unit/test_faiss_utils.py
+++ b/tests/unit/test_faiss_utils.py
@@ -15,42 +15,90 @@ def cleanup_faiss_module(monkeypatch):
         sys.modules["faiss"] = original
 
 
-def test_is_faiss_gpu_available_false_when_module_missing(monkeypatch):
-    monkeypatch.delitem(sys.modules, "faiss", raising=False)
+def _reload_utils():
     faiss_utils = importlib.import_module("src.core.faiss_utils")
-    importlib.reload(faiss_utils)
+    return importlib.reload(faiss_utils)
+
+
+def test_gpu_helpers_absent(monkeypatch):
+    monkeypatch.delitem(sys.modules, "faiss", raising=False)
+    faiss_utils = _reload_utils()
 
     assert faiss_utils.is_faiss_gpu_available() is False
+    assert faiss_utils.try_index_cpu_to_gpu("idx") is None
+    assert faiss_utils.ensure_cpu_index("idx") == "idx"
+
+    # Even without FAISS, setting threads should be a no-op
+    faiss_utils.set_faiss_threads(4)
 
 
-def test_is_faiss_gpu_available_true_when_functions_present(monkeypatch):
-    fake_faiss = SimpleNamespace(
-        StandardGpuResources=object,
-        index_cpu_to_all_gpus=lambda index: f"gpu:{index}",
-        index_gpu_to_cpu=lambda index: f"cpu:{index}",
-        get_num_gpus=lambda: 2,
-    )
+def test_gpu_helpers_present(monkeypatch):
+    calls: list[tuple[str, int]] = []
+
+    class FakeFaiss(SimpleNamespace):
+        def get_num_gpus(self):
+            return 2
+
+        def index_cpu_to_all_gpus(self, index):
+            return f"gpu:{index}"
+
+        def index_gpu_to_cpu(self, index):
+            return f"cpu:{index}"
+
+        def omp_set_num_threads(self, value: int):
+            calls.append(("omp", value))
+
+        def set_num_threads(self, value: int):
+            calls.append(("set", value))
+
+    fake_faiss = FakeFaiss(StandardGpuResources=object)
     monkeypatch.setitem(sys.modules, "faiss", fake_faiss)
-    faiss_utils = importlib.import_module("src.core.faiss_utils")
-    importlib.reload(faiss_utils)
+
+    faiss_utils = _reload_utils()
 
     assert faiss_utils.is_faiss_gpu_available() is True
 
-    gpu_index = faiss_utils.clone_index_to_gpu("idx")
+    faiss_utils.set_faiss_threads(8)
+    assert ("omp", 8) in calls
+
+    gpu_index = faiss_utils.try_index_cpu_to_gpu("idx")
     assert gpu_index == "gpu:idx"
 
-    cpu_index = faiss_utils.clone_index_to_cpu(gpu_index)
+    cpu_index = faiss_utils.ensure_cpu_index(gpu_index)
     assert cpu_index == "cpu:gpu:idx"
 
 
-def test_clone_index_to_gpu_returns_none_when_unavailable(monkeypatch):
+def test_set_threads_falls_back(monkeypatch):
+    calls: list[tuple[str, int]] = []
+
+    class FakeFaiss(SimpleNamespace):
+        def get_num_gpus(self):
+            return 1
+
+        def index_cpu_to_all_gpus(self, index):
+            return f"gpu:{index}"
+
+        def index_gpu_to_cpu(self, index):
+            return f"cpu:{index}"
+
+        def set_num_threads(self, value: int):
+            calls.append(("set", value))
+
+    fake_faiss = FakeFaiss(StandardGpuResources=object)
+    monkeypatch.setitem(sys.modules, "faiss", fake_faiss)
+
+    faiss_utils = _reload_utils()
+
+    faiss_utils.set_faiss_threads(6)
+    assert calls == [("set", 6)]
+
+
+def test_try_index_cpu_to_gpu_returns_none_when_not_supported(monkeypatch):
     fake_faiss = SimpleNamespace(get_num_gpus=lambda: 0)
     monkeypatch.setitem(sys.modules, "faiss", fake_faiss)
-    faiss_utils = importlib.import_module("src.core.faiss_utils")
-    importlib.reload(faiss_utils)
+
+    faiss_utils = _reload_utils()
 
     assert faiss_utils.is_faiss_gpu_available() is False
-    assert faiss_utils.clone_index_to_gpu("idx") is None
-
-    # Without GPU helpers, clone_index_to_cpu should return the input unchanged
-    assert faiss_utils.clone_index_to_cpu("idx") == "idx"
+    assert faiss_utils.try_index_cpu_to_gpu("idx") is None
+    assert faiss_utils.ensure_cpu_index("idx") == "idx"


### PR DESCRIPTION
## Summary
- add a device selection helper and CLI flags for GPU usage and FAISS threading in `lc_build_index.py`
- refactor FAISS utilities to expose CPU/GPU helpers and reuse them throughout the index merge flow
- document the new options and extend unit coverage for device picking and FAISS helpers

## Testing
- pytest tests/unit/test_faiss_utils.py tests/unit/test_build_index.py
- pytest tests/unit/test_retriever_gpu.py

------
https://chatgpt.com/codex/tasks/task_e_68cd5aaaed6c832ca51f3d7050e00af2