### PR TITLE
Fix verification harness to match LangChain CLIs

### DIFF
--- a/run_rag_verification.py
+++ b/run_rag_verification.py
@@ -177,7 +177,6 @@ def run_multi_agent(
     command = [
         sys.executable,
         str(script_path),
-        "ask",
         question,
         "--key",
         key,

--- a/tests/unit/test_run_rag_verification.py
+++ b/tests/unit/test_run_rag_verification.py
@@ -107,10 +107,10 @@ def test_run_lc_ask_invokes_cli_with_question_and_key(
     assert captured["cwd"] == repo_root
 
 
-def test_run_multi_agent_invokes_ask_subcommand(
+def test_run_multi_agent_invokes_cli_directly(
     monkeypatch: pytest.MonkeyPatch, repo_root: Path
 ) -> None:
-    """``run_multi_agent`` should execute the Typer ``ask`` sub-command."""
+    """``run_multi_agent`` should execute the Typer CLI with question and key."""
 
     captured: dict[str, object] = {}
 
@@ -139,14 +139,7 @@ def test_run_multi_agent_invokes_ask_subcommand(
         cwd=repo_root,
     )
 
-    expected = [
-        sys.executable,
-        str(script_path),
-        "ask",
-        question,
-        "--key",
-        key,
-    ]
+    expected = [sys.executable, str(script_path), question, "--key", key]
     assert captured["command"] == expected
     assert captured["cwd"] == repo_root
 


### PR DESCRIPTION
## Summary
- update the RAG verification harness to invoke lc_build_index, lc_ask, and multi_agent with their current command-line interfaces and clean up generated indices
- add targeted unit tests that lock down the new command invocations and cleanup behaviour

## Testing
- pytest tests/unit/test_run_rag_verification.py -q
- pytest -q *(fails: faiss dependency unavailable in the test environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d25b824114832cb7146b3b84f2c474