### PR TITLE
Handle optional FAISS/libmagic dependencies and GPU fallbacks

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -17,3 +17,4 @@ markers =
     integration: Integration tests
     slow: Slow running tests
     network: Tests that require network access
+asyncio_mode = auto

--- a/src/config/settings.py
+++ b/src/config/settings.py
@@ -149,13 +149,14 @@ class AppConfig:
     def _determine_parallel_workers(self) -> int:
         """Resolve the default parallel worker count from env or system state."""
 
-        env_value = os.getenv("PARALLEL_WORKERS_COUNT", os.cpu_count())
-
-        if env_value is not None:
+        for env_var in ("RAG_PARALLEL_WORKERS", "PARALLEL_WORKERS_COUNT"):
+            env_value = os.getenv(env_var)
+            if env_value is None or str(env_value).strip() == "":
+                continue
             try:
                 return self._clamp_parallel_workers(int(env_value))
             except (TypeError, ValueError):
-                pass
+                continue
 
         cpu_count = os.cpu_count() or 1
         return self._clamp_parallel_workers(cpu_count)

--- a/src/langchain/__init__.py
+++ b/src/langchain/__init__.py
@@ -5,5 +5,7 @@ This package contains tools for generating content using LangChain,
 including outline processing, batch processing, and content merging.
 """
 
+from . import _embeddings_compat  # noqa: F401
+
 __version__ = "1.0.0"
 __author__ = "LangChain Content Generation Team"

--- a/src/langchain/_embeddings_compat.py
+++ b/src/langchain/_embeddings_compat.py
@@ -1,0 +1,35 @@
+"""Compatibility helpers for LangChain embedding interfaces."""
+
+from __future__ import annotations
+
+from typing import Iterable, Sequence
+
+from langchain_core.embeddings import Embeddings
+from langchain_community.vectorstores.faiss import FAISS
+
+
+def _call_embedder(embedding_fn, method: str, *args):
+    if isinstance(embedding_fn, Embeddings):
+        return getattr(embedding_fn, method)(*args)
+    if hasattr(embedding_fn, method):
+        return getattr(embedding_fn, method)(*args)
+    if callable(embedding_fn):
+        return embedding_fn(*args)
+    raise TypeError(
+        f"Embedding function must implement '{method}' or be callable; got {type(embedding_fn)}"
+    )
+
+
+def _embed_query(self: FAISS, text: str) -> Sequence[float]:  # type: ignore[override]
+    return _call_embedder(self.embedding_function, "embed_query", text)
+
+
+def _embed_documents(self: FAISS, texts: Iterable[str]):  # type: ignore[override]
+    return _call_embedder(self.embedding_function, "embed_documents", list(texts))
+
+
+if not getattr(FAISS, "_ragwriter_embed_patch", False):
+    FAISS._embed_query = _embed_query  # type: ignore[assignment]
+    FAISS._embed_documents = _embed_documents  # type: ignore[assignment]
+    FAISS._ragwriter_embed_patch = True
+

--- a/src/langchain/faiss_utils.py
+++ b/src/langchain/faiss_utils.py
@@ -1,0 +1,20 @@
+"""LangChain-facing FAISS helpers exposing core utilities."""
+
+from src.core.faiss_utils import (
+    clone_index_to_cpu,
+    clone_index_to_gpu,
+    ensure_cpu_index,
+    is_faiss_gpu_available,
+    set_faiss_threads,
+    try_index_cpu_to_gpu,
+)
+
+__all__ = [
+    "clone_index_to_cpu",
+    "clone_index_to_gpu",
+    "ensure_cpu_index",
+    "is_faiss_gpu_available",
+    "set_faiss_threads",
+    "try_index_cpu_to_gpu",
+]
+


### PR DESCRIPTION
## Summary
- make FAISS utilities device-aware and expose them for langchain tests
- harden lc_build_index, embeddings compatibility, and manifest pipeline when optional deps are missing
- respect the RAG_PARALLEL_WORKERS env var and enable pytest asyncio mode

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68d2613cdfe8832cbb719c16aae10a7b