### PR TITLE
Fix verification harness CLI integration

### DIFF
--- a/tests/unit/test_run_rag_verification.py
+++ b/tests/unit/test_run_rag_verification.py
@@ -1,0 +1,29 @@
+"""Tests for helper utilities in ``run_rag_verification``."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from run_rag_verification import prepare_pdf_corpus
+
+
+def test_prepare_pdf_corpus_creates_pdfs(tmp_path: Path) -> None:
+    markdown_dir = tmp_path / "md"
+    markdown_dir.mkdir()
+    (markdown_dir / "sample.md").write_text("hello world\nsecond line", encoding="utf-8")
+
+    output_dir = tmp_path / "pdf"
+    pdf_paths = prepare_pdf_corpus(markdown_dir, output_dir)
+
+    assert len(pdf_paths) == 1
+    pdf_path = pdf_paths[0]
+    assert pdf_path.exists()
+    assert pdf_path.stat().st_size > 0
+
+
+def test_prepare_pdf_corpus_requires_markdown(tmp_path: Path) -> None:
+    output_dir = tmp_path / "pdf"
+    with pytest.raises(FileNotFoundError):
+        prepare_pdf_corpus(tmp_path, output_dir)


### PR DESCRIPTION
## Summary
- convert verification corpus markdown into temporary PDFs and invoke lc_build_index with the current CLI contract
- adjust harness query execution to call lc_ask and multi_agent with the updated positional arguments and clean up generated artifacts
- add unit coverage for markdown-to-PDF conversion utilities used during index preparation

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68d278cfe708832c9d284dbbd9a23d96