### PR TITLE
Add TRACE instrumentation and verification transcript support

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ llama-index-vector-stores-lancedb>=0.2.0,<0.3
 
 python_magic
 prompt_toolkit
-rich
+rich>=13
 textual
 textual-dev
 cryptography

--- a/src/cli/multi_agent.py
+++ b/src/cli/multi_agent.py
@@ -3,10 +3,13 @@
 from __future__ import annotations
 
 import asyncio
+import os
+import time
 import typer
 
 from ..core.llm import LLMFactory
 from ..tool import ToolRegistry, create_rag_retrieve_tool, run_agent
+from ..langchain.trace import configure_emitter
 
 app = typer.Typer(add_completion=False)
 
@@ -18,8 +21,17 @@ def ask(
     mcp: str | None = typer.Option(
         None, "--mcp", help="Path to MCP server executable to register tools from"
     ),
+    trace: bool = typer.Option(False, "--trace", help="Emit TRACE events"),
+    trace_file: str | None = typer.Option(
+        None,
+        "--trace-file",
+        help="Optional path to tee TRACE events",
+    ),
 ) -> None:
     """Run the agent loop with RAG and optional MCP tools."""
+    emitter = configure_emitter(trace, trace_file=trace_file)
+    qid = os.getenv("TRACE_QID")
+
     registry = ToolRegistry()
     registry.register(create_rag_retrieve_tool(key))
     if mcp:
@@ -27,8 +39,121 @@ def ask(
 
     factory = LLMFactory()
     _, llm = factory.create_llm()
-    result = run_agent(llm, registry, question)
+    with emitter:
+        traced_llm = _wrap_llm_with_trace(llm, emitter, qid)
+        _wrap_registry_with_trace(registry, emitter, qid)
+        result = run_agent(traced_llm, registry, question)
     typer.echo(result)
+
+
+def _wrap_llm_with_trace(llm, emitter, qid: str | None):
+    if not emitter.enabled:
+        return llm
+
+    def _invoke(messages):
+        span = emitter.make_span("llm.turn")
+        emitter.emit(
+            {
+                "qid": qid,
+                "span": span,
+                "parent": "root",
+                "role": "user",
+                "type": "llm.prompt",
+                "name": "multi_agent.llm",
+                "detail": {"messages": messages},
+            }
+        )
+        start = time.perf_counter()
+        if hasattr(llm, "invoke"):
+            response = llm.invoke(messages)  # type: ignore[attr-defined]
+        else:
+            response = llm(messages)
+        latency_ms = (time.perf_counter() - start) * 1000
+        if isinstance(response, dict) and "content" in response:
+            content = response["content"]
+        else:
+            content = str(response)
+        emitter.emit(
+            {
+                "qid": qid,
+                "span": span,
+                "parent": "root",
+                "role": "assistant",
+                "type": "llm.completion",
+                "name": "multi_agent.llm",
+                "detail": {"content": content, "finish_reason": "stop"},
+                "metrics": {"latency_ms": round(latency_ms, 2)},
+            }
+        )
+        return response
+
+    class _LLMWrapper:
+        def invoke(self, messages):
+            return _invoke(messages)
+
+    return _LLMWrapper()
+
+
+def _wrap_registry_with_trace(registry: ToolRegistry, emitter, qid: str | None) -> None:
+    if not emitter.enabled:
+        return
+
+    original_run = registry.run
+
+    def traced_run(name: str, **kwargs):
+        span = emitter.make_span("tool.call")
+        event_type = "mcp.call" if name in getattr(registry, "_mcp_tools", {}) else "tool.call"
+        emitter.emit(
+            {
+                "qid": qid,
+                "span": span,
+                "parent": "root",
+                "role": "mcp" if event_type.startswith("mcp") else "tool",
+                "type": event_type,
+                "name": name,
+                "detail": {"args": kwargs},
+            }
+        )
+        start = time.perf_counter()
+        try:
+            result = original_run(name, **kwargs)
+        except Exception as exc:
+            emitter.emit(
+                {
+                    "qid": qid,
+                    "span": span,
+                    "parent": "root",
+                    "role": "mcp" if event_type.startswith("mcp") else "tool",
+                    "type": "mcp.result" if event_type.startswith("mcp") else "tool.result",
+                    "name": name,
+                    "detail": {"ok": False, "error": str(exc)},
+                }
+            )
+            raise
+        latency_ms = (time.perf_counter() - start) * 1000
+        detail = {"ok": True}
+        if isinstance(result, dict):
+            if "items" in result and isinstance(result["items"], list):
+                detail["item_count"] = len(result["items"])
+            for key in ("items", "result", "output"):
+                if key in result:
+                    detail[key] = result[key]
+                    break
+        emitter.emit(
+            {
+                "qid": qid,
+                "span": span,
+                "parent": "root",
+                "role": "mcp" if event_type.startswith("mcp") else "tool",
+                "type": "mcp.result" if event_type.startswith("mcp") else "tool.result",
+                "name": name,
+                "detail": detail,
+                "metrics": {"latency_ms": round(latency_ms, 2)},
+            }
+        )
+        return result
+
+    registry.run = traced_run  # type: ignore[assignment]
 
 
 if __name__ == "__main__":

--- a/src/langchain/trace.py
+++ b/src/langchain/trace.py
@@ -1,0 +1,156 @@
+"""Tracing utilities shared across CLI scripts."""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import sys
+import time
+import uuid
+from contextlib import AbstractContextManager
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Dict
+
+TRACE_PREFIX = "TRACE: "
+MAX_TEXT_LENGTH = 3000
+
+_SECRET_PATTERNS: tuple[re.Pattern[str], ...] = (
+    re.compile(r"(?i)sk-[a-z0-9]{20,}"),
+    re.compile(r"(?i)aws(.{0,20})?(secret|key)[^=]*=\S+"),
+    re.compile(r"(?i)authorization:\s*bearer\s+\S+"),
+    re.compile(r"(?i)(password|passwd|pwd)\s*[:=]\s*\S+"),
+)
+
+
+def _redact_string(value: str) -> str:
+    truncated = value
+    if len(truncated) > MAX_TEXT_LENGTH:
+        truncated = truncated[:MAX_TEXT_LENGTH] + "…"
+    for pattern in _SECRET_PATTERNS:
+        truncated = pattern.sub("REDACTED", truncated)
+    return truncated
+
+
+def redact(value: Any) -> Any:
+    """Recursively redact secrets and truncate long strings."""
+
+    if isinstance(value, dict):
+        return {k: redact(v) for k, v in value.items()}
+    if isinstance(value, list):
+        return [redact(v) for v in value]
+    if isinstance(value, tuple):
+        return tuple(redact(v) for v in value)
+    if isinstance(value, str):
+        return _redact_string(value)
+    return value
+
+
+def _utc_timestamp() -> str:
+    return (
+        datetime.now(timezone.utc)
+        .isoformat(timespec="milliseconds")
+        .replace("+00:00", "Z")
+    )
+
+
+def _ensure_parent(event: dict[str, Any]) -> None:
+    if "parent" not in event:
+        event["parent"] = "root"
+
+
+@dataclass
+class TraceEmitter(AbstractContextManager["TraceEmitter"]):
+    """Simple TRACE protocol emitter."""
+
+    enabled: bool = False
+    tee_path: str | None = None
+    redact_output: bool = True
+    stream: Any = sys.stderr
+
+    def __post_init__(self) -> None:
+        self._tee_handle = None
+        if self.tee_path:
+            path = Path(self.tee_path)
+            path.parent.mkdir(parents=True, exist_ok=True)
+            self._tee_handle = path.open("a", encoding="utf-8")
+
+    def close(self) -> None:
+        if self._tee_handle:
+            self._tee_handle.close()
+            self._tee_handle = None
+
+    def __exit__(self, *exc: object) -> None:  # type: ignore[override]
+        self.close()
+
+    def make_span(self, name: str, parent: str | None = None) -> str:
+        span = uuid.uuid4().hex[:8]
+        if parent is None:
+            parent = "root"
+        return span
+
+    def emit(self, event: dict[str, Any]) -> None:
+        if not self.enabled:
+            return
+        payload = dict(event)
+        payload.setdefault("v", 1)
+        payload.setdefault("ts", _utc_timestamp())
+        if "span" not in payload:
+            payload["span"] = uuid.uuid4().hex[:8]
+        _ensure_parent(payload)
+        if self.redact_output:
+            payload = redact(payload)
+        line = TRACE_PREFIX + json.dumps(payload, ensure_ascii=False)
+        self.stream.write(line + "\n")
+        self.stream.flush()
+        if self._tee_handle:
+            self._tee_handle.write(json.dumps(payload, ensure_ascii=False) + "\n")
+            self._tee_handle.flush()
+
+
+def configure_emitter(flag: bool, *, trace_file: str | None = None) -> TraceEmitter:
+    env_enabled = os.getenv("RAG_TRACE") in {"1", "true", "TRUE", "yes", "on"}
+    enabled = flag or env_enabled
+    return TraceEmitter(enabled=enabled, tee_path=trace_file)
+
+
+def timed_span(emitter: TraceEmitter, name: str, parent: str | None = None) -> "_SpanContext":
+    return _SpanContext(emitter=emitter, name=name, parent=parent)
+
+
+class _SpanContext(AbstractContextManager["_SpanContext"]):
+    def __init__(self, *, emitter: TraceEmitter, name: str, parent: str | None) -> None:
+        self.emitter = emitter
+        self.name = name
+        self.parent = parent
+        self.span_id = emitter.make_span(name, parent=parent) if emitter.enabled else uuid.uuid4().hex[:8]
+        self._start = None
+
+    def __enter__(self) -> "_SpanContext":
+        self._start = time.perf_counter()
+        return self
+
+    def __exit__(self, exc_type, exc, tb) -> None:  # type: ignore[override]
+        if not self.emitter.enabled:
+            return
+        latency_ms = None
+        if self._start is not None:
+            latency_ms = (time.perf_counter() - self._start) * 1000
+        detail: Dict[str, Any] = {"message": f"Span {self.name} completed"}
+        metrics: Dict[str, Any] = {}
+        if latency_ms is not None:
+            metrics["latency_ms"] = round(latency_ms, 2)
+        event = {
+            "span": self.span_id,
+            "parent": self.parent or "root",
+            "type": "info" if exc_type is None else "error",
+            "name": self.name,
+            "detail": detail,
+            "metrics": metrics,
+        }
+        if exc_type is not None:
+            detail["exception"] = repr(exc)
+        self.emitter.emit(event)
+


### PR DESCRIPTION
## Summary
- add a shared `TraceEmitter` helper with redaction utilities
- instrument `lc_ask.py`, `multi_agent.py`, and the verification harness to stream TRACE events, render a Rich view, and persist NDJSON transcripts
- extend the verification CLI documentation and tests to cover tracing, redaction, and transcript generation

## Testing
- `pytest tests/test_verification_cli.py`


------
https://chatgpt.com/codex/tasks/task_e_68d2948b3904832cade2873d3f78032d