### PR TITLE
Allow configuring lc index and chunk directories

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,6 +236,8 @@ make repack-faiss FAISS_DIR=storage/faiss_science__BAAI-bge-small-en-v1.5 OUT=st
 - `--k`: number of results to return from vector database
 - `--embed-model`: the model index to query (default:`BAAI/bge-small-en-v1.5`)
 - `--ce-model`: cross encoder model (default: `cross-encoder/ms-marco-MiniLM-L-6-v2`)
+- `--chunks-dir`: directory containing the chunk JSONL written by `lc_build_index`
+- `--index-dir`: directory containing FAISS index folders (usually the same `--index-dir` passed to `lc_build_index`)
 
 **Usage**:
 
@@ -334,6 +336,9 @@ make lc-batch FILE="examples/sample_jobs_1A1.jsonl" KEY="biology" PARALLEL=4
 - `--no-gpu`: Force embeddings to run on CPU even if accelerators are available
 - `--serve-gpu`: After saving, copy the in-memory FAISS index to GPU for serving
 - `--faiss-threads`: Override FAISS build thread count (default: host CPU count)
+- `--input-dir`: Directory containing source PDFs to ingest (default: `data_raw/`)
+- `--chunks-dir`: Directory for normalized chunk JSONL output (default: `data_processed/`)
+- `--index-dir`: Directory that will contain FAISS index folders (default: `storage/`)
 
 **Usage**:
 ```bash

--- a/docs/rag-writer.1
+++ b/docs/rag-writer.1
@@ -476,6 +476,12 @@ The index builder CLI supports the following arguments:
 \fB--serve-gpu\fP — after saving, copy the in-memory FAISS index to GPU for serving
 .IP \[bu] 2
 \fB--faiss-threads\fP \fIN\fP — override FAISS thread count (defaults to host CPU count)
+.IP \[bu] 2
+\fB--input-dir\fP \fIPATH\fP — directory containing source PDFs (defaults to \fIdata_raw\fP)
+.IP \[bu] 2
+\fB--chunks-dir\fP \fIPATH\fP — directory for normalized chunk JSONL output (defaults to \fIdata_processed\fP)
+.IP \[bu] 2
+\fB--index-dir\fP \fIPATH\fP — directory that holds FAISS index folders (defaults to \fIstorage\fP)
 .sp
 .nf
 

--- a/tests/langchain/test_lc_ask_cli.py
+++ b/tests/langchain/test_lc_ask_cli.py
@@ -67,13 +67,13 @@ def test_lc_ask_supports_question_flag(monkeypatch, tmp_path):
 
     monkeypatch.chdir(tmp_path)
 
-    chunks_path = Path("data_processed")
+    chunks_path = tmp_path / "data_processed"
     chunks_path.mkdir(exist_ok=True)
     chunks_file = chunks_path / f"lc_chunks_{key}.jsonl"
     chunks_file.write_text(json.dumps({"text": "Sample", "metadata": {}}) + "\n", encoding="utf-8")
 
     emb_safe = "BAAI-bge-small-en-v1.5"
-    faiss_dir = Path("storage") / f"faiss_{key}__{emb_safe}"
+    faiss_dir = (tmp_path / "storage") / f"faiss_{key}__{emb_safe}"
     faiss_dir.mkdir(parents=True, exist_ok=True)
     (faiss_dir / "index.faiss").write_text("", encoding="utf-8")
 
@@ -115,9 +115,96 @@ def test_lc_ask_supports_question_flag(monkeypatch, tmp_path):
             key,
             "--question",
             question,
+            "--chunks-dir",
+            str(chunks_path),
+            "--index-dir",
+            str(tmp_path / "storage"),
         ],
     )
 
     lc_ask.main()
 
     assert captured["payload"]["query"] == question
+
+
+def test_lc_ask_accepts_custom_directories(monkeypatch, tmp_path):
+    _install_dummy_langchain_modules(monkeypatch)
+    lc_ask = importlib.import_module("src.langchain.lc_ask")
+
+    key = "custom/index"
+    question = "What is neuroplasticity?"
+
+    chunks_dir = tmp_path / "chunks"
+    chunks_dir.mkdir()
+    emb_safe = "BAAI-bge-small-en-v1.5"
+    safe_key = "custom-index"
+    chunk_file = chunks_dir / f"lc_chunks_{safe_key}.jsonl"
+    chunk_file.write_text(
+        json.dumps({"text": "Sample", "metadata": {}}) + "\n",
+        encoding="utf-8",
+    )
+
+    index_dir = tmp_path / "index"
+    faiss_dir = index_dir / f"faiss_{safe_key}__{emb_safe}"
+    faiss_dir.mkdir(parents=True, exist_ok=True)
+    (faiss_dir / "index.faiss").write_text("", encoding="utf-8")
+
+    class DummyEmbeddings:
+        pass
+
+    class DummyVectorStore:
+        pass
+
+    chunk_call = {}
+    faiss_call = {}
+
+    monkeypatch.setattr(lc_ask, "HuggingFaceEmbeddings", lambda model_name: DummyEmbeddings())
+
+    def fake_load_chunks(path):
+        chunk_call["path"] = Path(path)
+        return [lc_ask.Document("Sample", {})]
+
+    def fake_load_local(path, *args, **kwargs):
+        faiss_call["path"] = Path(path)
+        return DummyVectorStore()
+
+    monkeypatch.setattr(lc_ask, "_load_chunks_jsonl", fake_load_chunks)
+    monkeypatch.setattr(lc_ask.FAISS, "load_local", fake_load_local)
+    monkeypatch.setattr(lc_ask, "make_retriever", lambda **kwargs: object())
+
+    class DummyChain:
+        def invoke(self, payload):
+            return {"result": "ok", "source_documents": []}
+
+    class DummyLLM:
+        model_name = "dummy"
+        temperature = 0
+
+    monkeypatch.setattr(
+        lc_ask.RetrievalQA,
+        "from_chain_type",
+        lambda *args, **kwargs: DummyChain(),
+    )
+    monkeypatch.setattr(lc_ask, "ChatOpenAI", lambda **kwargs: DummyLLM())
+
+    monkeypatch.setenv("TRACE_QID", "test-qid")
+    monkeypatch.setattr(
+        lc_ask.sys,
+        "argv",
+        [
+            "lc_ask.py",
+            "--key",
+            key,
+            "--question",
+            question,
+            "--chunks-dir",
+            str(chunks_dir),
+            "--index-dir",
+            str(index_dir),
+        ],
+    )
+
+    lc_ask.main()
+
+    assert chunk_call["path"] == chunk_file
+    assert faiss_call["path"] == faiss_dir

--- a/tests/langchain/test_lc_build_index_resume.py
+++ b/tests/langchain/test_lc_build_index_resume.py
@@ -1,5 +1,12 @@
 import sys
+import types
+from pathlib import Path
+
+faiss_stub = types.ModuleType("faiss")
+sys.modules.setdefault("faiss", faiss_stub)
+
 from langchain_core.documents import Document
+
 from src.langchain import lc_build_index
 
 
@@ -20,3 +27,61 @@ def test_lc_build_index_accepts_resume_value(monkeypatch):
     lc_build_index.main()
 
     assert called["resume"] is True
+
+
+def test_lc_build_index_respects_custom_output_dirs(monkeypatch, tmp_path):
+    docs = [Document(page_content="test", metadata={})]
+    monkeypatch.setattr(lc_build_index, "load_pdfs", lambda: docs)
+
+    recorded = {}
+
+    def fake_write(chunks, out_path):
+        recorded["chunks_out"] = out_path
+
+    def fake_splitter(*args, **kwargs):  # pragma: no cover - helper
+        class _DummySplitter:
+            def split_documents(self, docs):
+                return docs
+
+        return _DummySplitter()
+
+    def fake_build(chunks, key, embedding_models, shard_size, resume, keep_shards, **_):
+        recorded["index_dir"] = lc_build_index.INDEX_DIR
+        recorded["key"] = key
+        recorded["embedding_models"] = embedding_models
+        return None
+
+    monkeypatch.setattr(lc_build_index, "write_chunks_jsonl", fake_write)
+    monkeypatch.setattr(lc_build_index, "RecursiveCharacterTextSplitter", fake_splitter)
+    monkeypatch.setattr(lc_build_index, "build_faiss_for_models", fake_build)
+
+    key = "custom/index"
+    chunks_dir = tmp_path / "chunks"
+    index_dir = tmp_path / "index"
+    input_dir = tmp_path / "input"
+    input_dir.mkdir()
+
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "lc_build_index.py",
+            key,
+            "--input-dir",
+            str(input_dir),
+            "--chunks-dir",
+            str(chunks_dir),
+            "--index-dir",
+            str(index_dir),
+            "--shard-size",
+            "10",
+        ],
+    )
+
+    lc_build_index.main()
+
+    safe_key = lc_build_index._fs_safe(key)
+    assert recorded["key"] == key
+    assert recorded["embedding_models"]
+    assert recorded["chunks_out"] == Path(chunks_dir) / f"lc_chunks_{safe_key}.jsonl"
+    assert Path(recorded["index_dir"]) == Path(index_dir)


### PR DESCRIPTION
## Summary
- allow overriding the chunk and index directories for lc_build_index and lc_ask CLIs
- normalize key names when persisting chunk files and FAISS directories so custom paths are safe
- document the new options in the README and CLI man page and extend unit tests for the new behavior

## Testing
- pytest tests/langchain/test_lc_ask_cli.py tests/langchain/test_lc_build_index_resume.py

------
https://chatgpt.com/codex/tasks/task_e_68d2a452c55c832cb8bd702a749d8574