### PR TITLE
Support direct index paths in lc_ask

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,11 +232,13 @@ make repack-faiss FAISS_DIR=storage/faiss_science__BAAI-bge-small-en-v1.5 OUT=st
 - Retrieval-augmented generation (RAG)
 
 **Options:**
-- `--key`: string specifying the faiss index to query
+- `--key`: collection key used when building the index (requires matching `--chunks-dir`)
+- `--index`: path to a FAISS index directory (or `index.faiss`) when you want to point directly at a built index
 - `--k`: number of results to return from vector database
 - `--embed-model`: the model index to query (default:`BAAI/bge-small-en-v1.5`)
 - `--ce-model`: cross encoder model (default: `cross-encoder/ms-marco-MiniLM-L-6-v2`)
 - `--chunks-dir`: directory containing the chunk JSONL written by `lc_build_index`
+- `--chunks-file`: explicit path to a chunk JSONL file (skips `--chunks-dir` lookup)
 - `--index-dir`: directory containing FAISS index folders (usually the same `--index-dir` passed to `lc_build_index`)
 
 **Usage**:
@@ -244,6 +246,9 @@ make repack-faiss FAISS_DIR=storage/faiss_science__BAAI-bge-small-en-v1.5 OUT=st
 ```bash
 # Basic query
 python src/langchain/lc_ask.py ask "What is machine learning?"
+
+# Query using an explicit index directory
+python src/langchain/lc_ask.py --index storage/faiss_science__BAAI-bge-small-en-v1.5 --question "Summarise the Higgs boson"
 
 # Advanced query with options
 python src/langchain/lc_ask.py ask "Explain neural networks" --content-type technical_manual_writer --key science --k 20

--- a/docs/rag-writer.1
+++ b/docs/rag-writer.1
@@ -158,7 +158,9 @@ Start with specific collection:
 [\fB\-\-task\fR \fITASK\fR]
 [\fB\-\-json\fR \fIFILE\fR]
 [\fB\-\-key\fR \fIKEY\fR]
+[\fB\-\-index\fR \fIPATH\fR]
 [\fB\-\-k\fR \fINUM\fR]
+[\fB\-\-chunks-file\fR \fIFILE\fR]
 [\fB\-\-output\fR \fIFILE\fR]
 [\fIinstruction\fR]
 .SS OPTIONS
@@ -173,10 +175,16 @@ The task/prompt for the LLM
 JSON file with job specification
 .TP
 .B \-\-key \fIKEY\fR
-Collection key for RAG (default: default)
+Collection key for RAG (default: default). One of \fB--key\fR or \fB--index\fR is required.
+.TP
+.B \-\-index \fIPATH\fR
+Path to a FAISS index directory (or \fIindex.faiss\fR) when addressing an explicit index location.
 .TP
 .B \-\-k \fINUM\fR
 Top-k results for retrieval (default: 30)
+.TP
+.B \-\-chunks-file \fIFILE\fR
+Explicit chunk JSONL file to load (overrides automatic lookup in \fB--chunks-dir\fR).
 .TP
 .B \-\-output \fIFILE\fR
 Output file path

--- a/src/langchain/lc_ask.py
+++ b/src/langchain/lc_ask.py
@@ -41,6 +41,93 @@ def _load_chunks_jsonl(path: Path) -> list[Document]:
     return docs
 
 
+def _infer_key_from_index_dir(path: Path) -> str | None:
+    name = path.name
+    if name == "index.faiss":
+        name = path.parent.name
+    if name.endswith("_repacked"):
+        name = name[: -len("_repacked")]
+    if name.startswith("faiss_"):
+        name = name[len("faiss_") :]
+        if "__" in name:
+            name = name.split("__", 1)[0]
+    if not name:
+        return None
+    return _fs_safe(name)
+
+
+def _resolve_faiss_directory(path: Path) -> tuple[Path, str | None]:
+    if not path.exists():
+        raise SystemExit(f"[lc_ask] index path not found: {path}")
+    if path.is_file():
+        if path.name != "index.faiss":
+            raise SystemExit(
+                "[lc_ask] --index must point to a directory or index.faiss file"
+            )
+        path = path.parent
+    if (path / "index.faiss").exists():
+        return path, _infer_key_from_index_dir(path)
+    candidates = [p for p in path.iterdir() if p.is_dir() and (p / "index.faiss").exists()]
+    if len(candidates) == 1:
+        return candidates[0], _infer_key_from_index_dir(candidates[0])
+    if not candidates:
+        raise SystemExit(
+            f"[lc_ask] index.faiss not found in {path}. Provide --index pointing to the directory containing index.faiss"
+        )
+    raise SystemExit(
+        "[lc_ask] multiple FAISS directories found; pass --index with the desired directory"
+    )
+
+
+def _locate_chunks_file(
+    *,
+    explicit_path: str | None,
+    chunks_dir: Path,
+    key_safe: str | None,
+    index_dir: Path | None,
+) -> Path | None:
+    if explicit_path:
+        candidate = Path(explicit_path).expanduser()
+        if not candidate.exists():
+            raise SystemExit(f"[lc_ask] chunks file not found: {candidate}")
+        return candidate
+    if key_safe:
+        candidate = chunks_dir / f"lc_chunks_{key_safe}.jsonl"
+        if candidate.exists():
+            return candidate
+    if index_dir is not None:
+        for pattern in ("lc_chunks_*.jsonl", "*.jsonl"):
+            matches = sorted(index_dir.glob(pattern))
+            if matches:
+                return matches[0]
+    return None
+
+
+def _extract_docs_from_vectorstore(vectorstore) -> list[Document] | None:
+    docstore = getattr(vectorstore, "docstore", None)
+    if docstore is None:
+        return None
+    records = None
+    if hasattr(docstore, "_dict"):
+        records = list(getattr(docstore, "_dict").values())
+    elif hasattr(docstore, "values"):
+        records = list(docstore.values())
+    if not records:
+        return None
+    docs: list[Document] = []
+    for item in records:
+        if isinstance(item, Document):
+            docs.append(item)
+        elif isinstance(item, dict) and "page_content" in item:
+            docs.append(
+                Document(
+                    page_content=item["page_content"],
+                    metadata=item.get("metadata", {}),
+                )
+            )
+    return docs or None
+
+
 def main():
     root = Path(__file__).resolve().parents[2]
 
@@ -53,7 +140,13 @@ def main():
         help="Question to ask (overrides positional QUESTION)",
     )
     parser.add_argument("--json", dest="json_path", help="JSON job file containing 'question'")
-    parser.add_argument("--key", required=True, help="collection key used at index time")
+    key_group = parser.add_mutually_exclusive_group(required=True)
+    key_group.add_argument("--key", help="collection key used at index time")
+    key_group.add_argument(
+        "--index",
+        dest="index_path",
+        help="Path to a FAISS index directory (or index.faiss file)",
+    )
     parser.add_argument(
         "--mode",
         default="faiss",
@@ -79,6 +172,11 @@ def main():
         "--chunks-dir",
         default=str(root / "data_processed"),
         help="Directory containing lc_build_index chunk outputs",
+    )
+    parser.add_argument(
+        "--chunks-file",
+        dest="chunks_file",
+        help="Explicit path to chunk JSONL (overrides --chunks-dir lookup)",
     )
     parser.add_argument(
         "--index-dir",
@@ -107,48 +205,65 @@ def main():
     chunks_dir = Path(args.chunks_dir).expanduser()
     index_dir = Path(args.index_dir).expanduser()
 
-    key_safe = _fs_safe(args.key)
-    chunks_path = chunks_dir / f"lc_chunks_{key_safe}.jsonl"
-    if not chunks_path.exists():
-        raise SystemExit(
-            f"[lc_ask] chunks not found: {chunks_path} – run lc_build_index for KEY={args.key}"
-        )
-    docs = _load_chunks_jsonl(chunks_path)
+    docs: list[Document] | None = None
+    faiss_dir: Path | None = None
+    key_safe: str | None = None
 
-    emb_name_safe = re.sub(r"[^a-zA-Z0-9._-]+", "-", args.embed_model)
-    base_dir = index_dir / f"faiss_{key_safe}__{emb_name_safe}"
-    repacked_dir = base_dir.parent / f"{base_dir.name}_repacked"
+    if args.key:
+        key_safe = _fs_safe(args.key)
+        emb_name_safe = re.sub(r"[^a-zA-Z0-9._-]+", "-", args.embed_model)
+        base_dir = index_dir / f"faiss_{key_safe}__{emb_name_safe}"
+        repacked_dir = base_dir.parent / f"{base_dir.name}_repacked"
 
-    # Prefer a repacked/merged index if available
-    faiss_dir = None
-    for cand in (repacked_dir, base_dir):
-        if (cand / "index.faiss").exists():
-            faiss_dir = cand
-            break
+        for cand in (repacked_dir, base_dir):
+            if (cand / "index.faiss").exists():
+                faiss_dir = cand
+                break
 
-    if faiss_dir is None:
-        if base_dir.exists():
-            shards = [p for p in base_dir.iterdir() if p.is_dir()]
-            if shards:
-                raise SystemExit(
-                    f"[lc_ask] FAISS shards found but no merged index: {base_dir}\n"
-                    "  • Merge shards before querying (merge step not completed)"
-                )
-        raise SystemExit(
-            "[lc_ask] FAISS dir not found: "
-            f"{base_dir} (or repacked: {repacked_dir}).\n"
-            f"  • If you upgraded LangChain, try: make repack-faiss KEY={args.key} EMBED_MODEL={args.embed_model}\n"
-            f"  • Or rebuild the index: python src/langchain/lc_build_index.py {args.key}"
-        )
+        if faiss_dir is None:
+            if base_dir.exists():
+                shards = [p for p in base_dir.iterdir() if p.is_dir()]
+                if shards:
+                    raise SystemExit(
+                        f"[lc_ask] FAISS shards found but no merged index: {base_dir}\n"
+                        "  • Merge shards before querying (merge step not completed)"
+                    )
+            raise SystemExit(
+                "[lc_ask] FAISS dir not found: "
+                f"{base_dir} (or repacked: {repacked_dir}).\n"
+                f"  • If you upgraded LangChain, try: make repack-faiss KEY={args.key} EMBED_MODEL={args.embed_model}\n"
+                f"  • Or rebuild the index: python src/langchain/lc_build_index.py {args.key}"
+            )
+    else:
+        faiss_dir, key_safe = _resolve_faiss_directory(Path(args.index_path).expanduser())
+
+    chunks_path = _locate_chunks_file(
+        explicit_path=args.chunks_file,
+        chunks_dir=chunks_dir,
+        key_safe=key_safe,
+        index_dir=faiss_dir,
+    )
+    if chunks_path is not None:
+        docs = _load_chunks_jsonl(chunks_path)
     embedder = HuggingFaceEmbeddings(model_name=args.embed_model)
     vectorstore = FAISS.load_local(
         str(faiss_dir), embeddings=embedder, allow_dangerous_deserialization=True
     )
 
+    if docs is None:
+        docs = _extract_docs_from_vectorstore(vectorstore)
+
+    docs_for_retriever = docs or []
+    modes_requiring_docs = {"bm25", "hybrid", "parent", "hybrid+compression"}
+    if not docs_for_retriever and args.mode in modes_requiring_docs:
+        raise SystemExit(
+            f"[lc_ask] Document chunks required for mode '{args.mode}'. Provide --key or --chunks-file"
+        )
+
     retriever = make_retriever(
         mode=args.mode,
         vectorstore=vectorstore,
-        docs=docs,
+        docs=docs_for_retriever,
         k=args.k,
         rerank=(None if args.rerank == "none" else args.rerank),
         ce_model=args.ce_model,

--- a/tests/langchain/test_lc_ask_cli.py
+++ b/tests/langchain/test_lc_ask_cli.py
@@ -208,3 +208,83 @@ def test_lc_ask_accepts_custom_directories(monkeypatch, tmp_path):
 
     assert chunk_call["path"] == chunk_file
     assert faiss_call["path"] == faiss_dir
+
+
+def test_lc_ask_accepts_index_path(monkeypatch, tmp_path):
+    _install_dummy_langchain_modules(monkeypatch)
+    lc_ask = importlib.import_module("src.langchain.lc_ask")
+
+    key = "custom/index"
+    question = "What is neuroplasticity?"
+
+    chunks_dir = tmp_path / "chunks"
+    chunks_dir.mkdir()
+    safe_key = "custom-index"
+    chunk_file = chunks_dir / f"lc_chunks_{safe_key}.jsonl"
+    chunk_file.write_text(
+        json.dumps({"text": "Sample", "metadata": {}}) + "\n",
+        encoding="utf-8",
+    )
+
+    index_root = tmp_path / "index"
+    faiss_dir = index_root / f"faiss_{safe_key}__BAAI-bge-small-en-v1.5"
+    faiss_dir.mkdir(parents=True, exist_ok=True)
+    (faiss_dir / "index.faiss").write_text("", encoding="utf-8")
+
+    class DummyEmbeddings:
+        pass
+
+    class DummyVectorStore:
+        pass
+
+    chunk_call = {}
+    faiss_call = {}
+
+    monkeypatch.setattr(lc_ask, "HuggingFaceEmbeddings", lambda model_name: DummyEmbeddings())
+
+    def fake_load_chunks(path):
+        chunk_call["path"] = Path(path)
+        return [lc_ask.Document("Sample", {})]
+
+    def fake_load_local(path, *args, **kwargs):
+        faiss_call["path"] = Path(path)
+        return DummyVectorStore()
+
+    monkeypatch.setattr(lc_ask, "_load_chunks_jsonl", fake_load_chunks)
+    monkeypatch.setattr(lc_ask.FAISS, "load_local", fake_load_local)
+    monkeypatch.setattr(lc_ask, "make_retriever", lambda **kwargs: object())
+
+    class DummyChain:
+        def invoke(self, payload):
+            return {"result": "ok", "source_documents": []}
+
+    class DummyLLM:
+        model_name = "dummy"
+        temperature = 0
+
+    monkeypatch.setattr(
+        lc_ask.RetrievalQA,
+        "from_chain_type",
+        lambda *args, **kwargs: DummyChain(),
+    )
+    monkeypatch.setattr(lc_ask, "ChatOpenAI", lambda **kwargs: DummyLLM())
+
+    monkeypatch.setenv("TRACE_QID", "test-qid")
+    monkeypatch.setattr(
+        lc_ask.sys,
+        "argv",
+        [
+            "lc_ask.py",
+            "--index",
+            str(faiss_dir),
+            "--question",
+            question,
+            "--chunks-dir",
+            str(chunks_dir),
+        ],
+    )
+
+    lc_ask.main()
+
+    assert chunk_call["path"] == chunk_file
+    assert faiss_call["path"] == faiss_dir


### PR DESCRIPTION
## Summary
- allow the `lc_ask` CLI to accept `--index` paths and optional `--chunks-file` overrides when querying an index
- add helpers to resolve FAISS directories, locate chunk metadata, and fall back to vectorstore docstores when needed
- extend CLI tests and update documentation to describe the new flags and usage examples

## Testing
- pytest tests/langchain/test_lc_ask_cli.py
- pytest *(fails: missing optional dependencies such as `faiss` and a `prepare_pdf_corpus` symbol)*

------
https://chatgpt.com/codex/tasks/task_e_68d2acbd6018832cbc12757cc7240156