### PR TITLE
Improve FAISS optionality and add verification PDF helper

### DIFF
--- a/src/core/faiss_merge_helpers.py
+++ b/src/core/faiss_merge_helpers.py
@@ -1,41 +1,80 @@
 from __future__ import annotations
+
+from typing import Any, Tuple
+
 import numpy as np
-import faiss
 
 from src.core.faiss_utils import ensure_cpu_index  # type: ignore
+
+try:  # pragma: no cover - exercised indirectly via tests
+    import faiss as _faiss  # type: ignore
+except ModuleNotFoundError as exc:  # pragma: no cover - import guarded by tests
+    _faiss = None
+    _FAISS_IMPORT_ERROR = exc
+else:  # pragma: no cover - executed in FAISS-enabled envs
+    _FAISS_IMPORT_ERROR = None
+
+# Re-export for backwards compatibility with existing imports.
+faiss = _faiss
+
+
+def _require_faiss() -> Any:
+    """Return the FAISS module or raise a helpful error if unavailable."""
+
+    if _faiss is None:
+        message = (
+            "faiss is required for CPU vectorstore merging. Install "
+            "'faiss-cpu' (or the appropriate GPU build) to enable this "
+            "functionality."
+        )
+        raise ModuleNotFoundError(message) from _FAISS_IMPORT_ERROR
+    return _faiss
+
+
+def _flat_types(faiss_module: Any) -> Tuple[type, ...]:
+    names = ("IndexFlat", "IndexFlatIP", "IndexFlatL2")
+    types = tuple(
+        getattr(faiss_module, name) for name in names if hasattr(faiss_module, name)
+    )
+    return types
 
 
 # ----------------------------- FAISS helpers -----------------------------
 
-def _metric_of(index: faiss.Index) -> int:
+
+def _metric_of(index: Any) -> int:
+    faiss_module = _require_faiss()
     try:
         return int(getattr(index, "metric_type"))
     except Exception:
-        if isinstance(index, faiss.IndexFlatIP):
-            return faiss.METRIC_INNER_PRODUCT
-        return faiss.METRIC_L2
+        flat_ip = getattr(faiss_module, "IndexFlatIP", None)
+        if flat_ip is not None and isinstance(index, flat_ip):
+            return faiss_module.METRIC_INNER_PRODUCT
+        return faiss_module.METRIC_L2
 
 
-def _new_flat_like(acc_index: faiss.Index) -> faiss.Index:
+def _new_flat_like(acc_index: Any) -> Any:
+    faiss_module = _require_faiss()
     """
     Create an empty FLAT index with same dim + metric as acc_index.
     Supports IndexFlat, IndexFlatIP, IndexFlatL2.
     """
     d = int(acc_index.d)
     mt = _metric_of(acc_index)
-    if mt == faiss.METRIC_INNER_PRODUCT:
+    if mt == faiss_module.METRIC_INNER_PRODUCT:
         try:
-            return faiss.IndexFlatIP(d)
+            return faiss_module.IndexFlatIP(d)
         except Exception:
-            return faiss.IndexFlat(d, mt)
+            return faiss_module.IndexFlat(d, mt)
     else:
         try:
-            return faiss.IndexFlatL2(d)
+            return faiss_module.IndexFlatL2(d)
         except Exception:
-            return faiss.IndexFlat(d, mt)
+            return faiss_module.IndexFlat(d, mt)
 
 
-def _extract_flat_vectors(idx: faiss.Index) -> np.ndarray:
+def _extract_flat_vectors(idx: Any) -> np.ndarray:
+    faiss_module = _require_faiss()
     """
     Return all vectors from a *flat* index as float32 [ntotal, d].
     Handles multiple FAISS Python variants.
@@ -47,7 +86,7 @@ def _extract_flat_vectors(idx: faiss.Index) -> np.ndarray:
 
     xb = getattr(idx, "xb", None)
     if xb is not None:
-        arr = faiss.vector_to_array(xb)  # 1-D float32
+        arr = faiss_module.vector_to_array(xb)  # 1-D float32
         return arr.reshape(nt, d)
 
     rec_n = getattr(idx, "reconstruct_n", None)
@@ -67,11 +106,13 @@ def _extract_flat_vectors(idx: faiss.Index) -> np.ndarray:
     raise TypeError(f"Cannot extract vectors from index type {type(idx)}")
 
 
-def _is_flat(idx: faiss.Index) -> bool:
-    return isinstance(idx, (faiss.IndexFlat, faiss.IndexFlatIP, faiss.IndexFlatL2))
+def _is_flat(idx: Any) -> bool:
+    faiss_module = _require_faiss()
+    return isinstance(idx, _flat_types(faiss_module))
 
 
 # ----------------------- LangChain mapping merge ------------------------
+
 
 def _idmap_len(idmap) -> int:
     """Length of index_to_docstore_id whether list or dict."""
@@ -127,7 +168,9 @@ def _merge_idmaps_inplace(acc_idmap, shard_idmap):
 
 # ----------------------------- Public API -------------------------------
 
+
 def merge_faiss_vectorstores_cpu(acc_vs, shard_vs):
+    _require_faiss()
     """
     Robust, CPU-only merge for LangChain FAISS vectorstores that:
       - Assumes *FLAT* indexes (IndexFlat / IndexFlatIP / IndexFlatL2).

--- a/tests/unit/test_faiss_merge_helpers.py
+++ b/tests/unit/test_faiss_merge_helpers.py
@@ -1,0 +1,29 @@
+"""Regression tests for ``src.core.faiss_merge_helpers``."""
+
+from __future__ import annotations
+
+import builtins
+import importlib
+import sys
+
+import pytest
+
+
+def test_import_succeeds_when_faiss_missing(monkeypatch):
+    """The helper module should not hard-crash if FAISS is absent."""
+
+    real_import = builtins.__import__
+
+    def fake_import(name, globals=None, locals=None, fromlist=(), level=0):
+        if name == "faiss":
+            raise ModuleNotFoundError("faiss not available")
+        return real_import(name, globals, locals, fromlist, level)
+
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+
+    module_name = "src.core.faiss_merge_helpers"
+    sys.modules.pop(module_name, None)
+    module = importlib.import_module(module_name)
+
+    with pytest.raises(ModuleNotFoundError):
+        module.merge_faiss_vectorstores_cpu(object(), object())

--- a/tests/unit/test_faiss_utils.py
+++ b/tests/unit/test_faiss_utils.py
@@ -102,3 +102,14 @@ def test_try_index_cpu_to_gpu_returns_none_when_not_supported(monkeypatch):
     assert faiss_utils.is_faiss_gpu_available() is False
     assert faiss_utils.try_index_cpu_to_gpu("idx") is None
     assert faiss_utils.ensure_cpu_index("idx") == "idx"
+
+
+def test_ensure_cpu_index_handles_missing_import(monkeypatch):
+    """Regression: missing importlib import should not raise."""
+
+    monkeypatch.delitem(sys.modules, "faiss", raising=False)
+
+    faiss_utils = _reload_utils()
+
+    sentinel = object()
+    assert faiss_utils.ensure_cpu_index(sentinel) is sentinel


### PR DESCRIPTION
## Summary
- add a lightweight Markdown-to-PDF helper so the verification script can prepare corpora without external tooling
- harden the FAISS merge helpers to tolerate missing bindings and raise clear errors only when functionality is needed
- cover the new behaviours with regression tests for the FAISS utilities and merge helpers

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68d2af2ee46c832ca542f99a7b01ff24