### PR TITLE
Add FAISS embedding dimension validation in lc_ask

### DIFF
--- a/src/langchain/lc_ask.py
+++ b/src/langchain/lc_ask.py
@@ -22,6 +22,50 @@ sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
 from src.langchain.retriever_factory import make_retriever
 
 
+def _get_embedding_dimension(embedder: HuggingFaceEmbeddings) -> int | None:
+    """Return the output dimension for a HuggingFace embedding model."""
+
+    client = getattr(embedder, "client", None)
+    if client is None:
+        return None
+
+    getter = getattr(client, "get_sentence_embedding_dimension", None)
+    if callable(getter):
+        try:
+            return int(getter())
+        except Exception:
+            return None
+
+    # Fallback for SentenceTransformer-like clients that expose `embedding_dim`
+    dim = getattr(client, "embedding_dim", None)
+    if isinstance(dim, int):
+        return dim
+
+    return None
+
+
+def _validate_index_embedding_compatibility(
+    embedder: HuggingFaceEmbeddings, vectorstore: FAISS, index_path: Path
+) -> None:
+    """Ensure the FAISS index dimension matches the embedding model output."""
+
+    index_dim = getattr(getattr(vectorstore, "index", None), "d", None)
+    embed_dim = _get_embedding_dimension(embedder)
+
+    if index_dim is None or embed_dim is None:
+        return
+
+    if index_dim != embed_dim:
+        model_name = getattr(embedder, "model_name", "(unknown)")
+        raise SystemExit(
+            "[lc_ask] Embedding dimension mismatch: "
+            f"index at {index_path} expects dimension {index_dim}, "
+            f"but embedding model '{model_name}' produces {embed_dim}.\n"
+            "  • Pass --embed-model with the model used to build the index, "
+            "or rebuild the index for the requested model."
+        )
+
+
 def _load_chunks_jsonl(path: Path) -> list[Document]:
     docs = []
     with path.open("r", encoding="utf-8") as f:
@@ -104,6 +148,7 @@ def main():
     vectorstore = FAISS.load_local(
         str(faiss_dir), embeddings=embedder, allow_dangerous_deserialization=True
     )
+    _validate_index_embedding_compatibility(embedder, vectorstore, faiss_dir)
 
     retriever = make_retriever(
         mode=args.mode,

--- a/tests/langchain/test_lc_ask_embedding_validation.py
+++ b/tests/langchain/test_lc_ask_embedding_validation.py
@@ -1,0 +1,100 @@
+import sys
+import types
+from pathlib import Path
+
+import pytest
+
+# Provide lightweight stubs for optional LangChain dependencies so lc_ask can import
+if "langchain_core.documents" not in sys.modules:
+    mod = types.ModuleType("langchain_core.documents")
+
+    class Document:  # pragma: no cover - stub for import-time use only
+        ...
+
+    mod.Document = Document
+    sys.modules["langchain_core.documents"] = mod
+
+if "langchain_community.vectorstores" not in sys.modules:
+    mod = types.ModuleType("langchain_community.vectorstores")
+
+    class _StubFAISS:  # pragma: no cover - stub for import-time use only
+        @staticmethod
+        def load_local(*_args, **_kwargs):
+            raise NotImplementedError
+
+    mod.FAISS = _StubFAISS
+    sys.modules["langchain_community.vectorstores"] = mod
+
+if "langchain_community.embeddings" not in sys.modules:
+    mod = types.ModuleType("langchain_community.embeddings")
+
+    class HuggingFaceEmbeddings:  # pragma: no cover - stub for import-time use only
+        def __init__(self, *args, **kwargs):  # noqa: D401 - stub
+            raise NotImplementedError
+
+    mod.HuggingFaceEmbeddings = HuggingFaceEmbeddings
+    sys.modules["langchain_community.embeddings"] = mod
+
+if "langchain_openai" not in sys.modules:
+    mod = types.ModuleType("langchain_openai")
+
+    class ChatOpenAI:  # pragma: no cover - stub for import-time use only
+        ...
+
+    mod.ChatOpenAI = ChatOpenAI
+    sys.modules["langchain_openai"] = mod
+
+if "langchain.chains" not in sys.modules:
+    mod = types.ModuleType("langchain.chains")
+
+    class RetrievalQA:  # pragma: no cover - stub for import-time use only
+        ...
+
+    mod.RetrievalQA = RetrievalQA
+    sys.modules["langchain.chains"] = mod
+
+from src.langchain import lc_ask
+
+
+class _DummyClient:
+    def __init__(self, dim: int) -> None:
+        self._dim = dim
+
+    def get_sentence_embedding_dimension(self) -> int:
+        return self._dim
+
+
+class _DummyEmbedder:
+    def __init__(self, dim: int) -> None:
+        self.client = _DummyClient(dim)
+
+
+class _DummyIndex:
+    def __init__(self, dim: int) -> None:
+        self.d = dim
+
+
+class _DummyVectorStore:
+    def __init__(self, dim: int) -> None:
+        self.index = _DummyIndex(dim)
+
+
+def test_validate_index_embedding_dimension_mismatch() -> None:
+    embedder = _DummyEmbedder(dim=384)
+    vectorstore = _DummyVectorStore(dim=768)
+
+    with pytest.raises(SystemExit) as excinfo:
+        lc_ask._validate_index_embedding_compatibility(
+            embedder, vectorstore, Path("/tmp/index")
+        )
+
+    assert "Embedding dimension mismatch" in str(excinfo.value)
+
+
+def test_validate_index_embedding_dimension_match() -> None:
+    embedder = _DummyEmbedder(dim=768)
+    vectorstore = _DummyVectorStore(dim=768)
+
+    lc_ask._validate_index_embedding_compatibility(
+        embedder, vectorstore, Path("/tmp/index")
+    )


### PR DESCRIPTION
## Summary
- add helper utilities in `lc_ask` to detect the embedding output dimension and ensure it matches the loaded FAISS index
- raise a descriptive `SystemExit` when the embedding model does not match the stored index, guiding the user to pick the right model
- cover the new validation logic with targeted unit tests that stub optional LangChain dependencies

## Testing
- pytest tests/langchain/test_lc_ask_embedding_validation.py


------
https://chatgpt.com/codex/tasks/task_e_68d2dbe52ba8832ca6b531bb30fe5c34