### PR TITLE
Align lc_ask storage flags with index builder

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,6 +236,9 @@ make repack-faiss FAISS_DIR=storage/faiss_science__BAAI-bge-small-en-v1.5 OUT=st
 - `--k`: number of results to return from vector database
 - `--embed-model`: the model index to query (default:`BAAI/bge-small-en-v1.5`)
 - `--ce-model`: cross encoder model (default: `cross-encoder/ms-marco-MiniLM-L-6-v2`)
+- `--chunks-dir`: directory containing chunk metadata generated at index build time (default: `<repo>/data_processed`)
+- `--index-dir`: directory holding FAISS index directories (default: `<repo>/storage`)
+- `--input-dir`: source corpus directory used during indexing (default: `<repo>/data_raw`)
 
 **Usage**:
 

--- a/docs/rag-writer.1
+++ b/docs/rag-writer.1
@@ -180,6 +180,15 @@ Top-k results for retrieval (default: 30)
 .TP
 .B \-\-output \fIFILE\fR
 Output file path
+.TP
+.B \-\-chunks-dir \fIDIR\fR
+Directory containing chunk metadata produced at index build time (default: repo/data_processed)
+.TP
+.B \-\-index-dir \fIDIR\fR
+Directory containing FAISS index directories (default: repo/storage)
+.TP
+.B \-\-input-dir \fIDIR\fR
+Directory containing the raw corpus used when building the index (default: repo/data_raw)
 .SS EXAMPLES
 .TP
 Ask a simple question:

--- a/tests/langchain/test_lc_ask_cli.py
+++ b/tests/langchain/test_lc_ask_cli.py
@@ -1,0 +1,104 @@
+from pathlib import Path
+from types import ModuleType, SimpleNamespace
+import sys
+
+import pytest
+
+
+# Provide lightweight stand-ins for optional LangChain dependencies so lc_ask can import.
+if "langchain_core.documents" not in sys.modules:
+    langchain_core = ModuleType("langchain_core")
+    langchain_core.documents = ModuleType("langchain_core.documents")
+
+    class _DummyDocument:
+        def __init__(self, page_content: str = "", metadata: dict | None = None) -> None:
+            self.page_content = page_content
+            self.metadata = metadata or {}
+
+    langchain_core.documents.Document = _DummyDocument
+    sys.modules["langchain_core"] = langchain_core
+    sys.modules["langchain_core.documents"] = langchain_core.documents
+
+if "langchain_community" not in sys.modules:
+    langchain_community = ModuleType("langchain_community")
+    langchain_community.__path__ = []  # mark as package
+    sys.modules["langchain_community"] = langchain_community
+
+if "langchain_community.vectorstores" not in sys.modules:
+    vectorstores = ModuleType("langchain_community.vectorstores")
+    vectorstores.FAISS = SimpleNamespace()
+    sys.modules["langchain_community.vectorstores"] = vectorstores
+
+if "langchain_community.retrievers" not in sys.modules:
+    retrievers = ModuleType("langchain_community.retrievers")
+
+    class _DummyRetriever:
+        @classmethod
+        def from_documents(cls, docs):
+            return cls()
+
+    retrievers.BM25Retriever = _DummyRetriever
+    retrievers.EnsembleRetriever = _DummyRetriever
+    retrievers.ContextualCompressionRetriever = _DummyRetriever
+    retrievers.ParentDocumentRetriever = _DummyRetriever
+    sys.modules["langchain_community.retrievers"] = retrievers
+
+if "langchain_community.document_transformers" not in sys.modules:
+    transformers = ModuleType("langchain_community.document_transformers")
+    transformers.CrossEncoderReranker = SimpleNamespace
+    sys.modules["langchain_community.document_transformers"] = transformers
+
+if "langchain_community.cross_encoders" not in sys.modules:
+    cross_encoders = ModuleType("langchain_community.cross_encoders")
+    cross_encoders.HuggingFaceCrossEncoder = SimpleNamespace
+    sys.modules["langchain_community.cross_encoders"] = cross_encoders
+
+if "langchain_huggingface" not in sys.modules:
+    langchain_huggingface = ModuleType("langchain_huggingface")
+    langchain_huggingface.HuggingFaceEmbeddings = object
+    sys.modules["langchain_huggingface"] = langchain_huggingface
+
+if "langchain_openai" not in sys.modules:
+    langchain_openai = ModuleType("langchain_openai")
+    langchain_openai.ChatOpenAI = object
+    sys.modules["langchain_openai"] = langchain_openai
+
+if "langchain" not in sys.modules:
+    langchain = ModuleType("langchain")
+    langchain.__path__ = []
+    sys.modules["langchain"] = langchain
+
+if "langchain.chains" not in sys.modules:
+    chains = ModuleType("langchain.chains")
+    chains.RetrievalQA = SimpleNamespace
+    sys.modules["langchain.chains"] = chains
+
+if "langchain.retrievers" not in sys.modules:
+    langchain_retrievers = ModuleType("langchain.retrievers")
+    langchain_retrievers.EnsembleRetriever = SimpleNamespace
+    langchain_retrievers.ContextualCompressionRetriever = SimpleNamespace
+    langchain_retrievers.ParentDocumentRetriever = SimpleNamespace
+    sys.modules["langchain.retrievers"] = langchain_retrievers
+
+from src.langchain import lc_ask
+
+
+@pytest.mark.parametrize(
+    "chunks_dir,index_dir",
+    [
+        (Path("/tmp/chunks"), Path("/tmp/storage")),
+        (Path("relative/chunks"), Path("relative/storage")),
+    ],
+)
+def test_resolve_paths_align_with_build_defaults(chunks_dir: Path, index_dir: Path) -> None:
+    chunk_path, base_dir, repacked_dir = lc_ask._resolve_paths(
+        key="demo",
+        embed_model="BAAI/bge-small-en-v1.5",
+        chunks_dir=chunks_dir,
+        index_dir=index_dir,
+    )
+
+    assert chunk_path == Path(chunks_dir) / "lc_chunks_demo.jsonl"
+    expected_base = Path(index_dir) / "faiss_demo__BAAI-bge-small-en-v1.5"
+    assert base_dir == expected_base
+    assert repacked_dir == expected_base.parent / f"{expected_base.name}_repacked"


### PR DESCRIPTION
## Summary
- add filesystem-safe path resolution helper to lc_ask and reuse lc_build_index directory conventions
- expose --input-dir, --chunks-dir, and --index-dir flags on lc_ask so callers can point at custom storage locations
- document the new CLI switches and cover the resolver with a focused unit test

## Testing
- pytest tests/langchain/test_lc_ask_cli.py

------
https://chatgpt.com/codex/tasks/task_e_68d2dca420dc832c8be231c32c81a04e