### PR TITLE
Expose index directory overrides for verification harness

### DIFF
--- a/.github/workflows/mcp.yml
+++ b/.github/workflows/mcp.yml
@@ -17,6 +17,7 @@ jobs:
         run: |
           python -m pip install -U pip
           if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+          if [ $GPU_COUNT -gt 0]; then pip install -r requirements-faiss-gpu.txt; else; pip install -r requirements-faiss-cpu.txt;fi
           if [ -f requirements-test.txt ]; then pip install -r requirements-test.txt; fi
       - name: Start MCP server
         run: |

--- a/eval/verification/rag_gold_corpus_neuroplasticity/docs/NP01_definition_scope.md
+++ b/eval/verification/rag_gold_corpus_neuroplasticity/docs/NP01_definition_scope.md
@@ -1,0 +1,2 @@
+# Neuroplasticity — Definition & Scope
+Neuroplasticity (aka neural plasticity) is the brain’s capacity to reorganize its structure and connections in response to learning, experience, injury, or environmental change. Changes range from synaptic adjustments and pathway rewiring to cortical remapping. The phenomenon persists into adulthood (not only childhood) and includes patterns like homologous area adaptation, cross‑modal reassignment, map expansion, and compensatory masquerade.

--- a/eval/verification/rag_gold_corpus_neuroplasticity/docs/NP02_history_milestones.md
+++ b/eval/verification/rag_gold_corpus_neuroplasticity/docs/NP02_history_milestones.md
@@ -1,0 +1,2 @@
+# History — Milestones
+Early hints appeared as far back as 1793 (Malacarne’s trained animals showed larger cerebellums). William James (1890) described “plasticity” of behavior; Santiago Ramón y Cajal argued for plastic changes even in adult brains. Acceptance remained limited until the mid‑20th century. In 1964 Marian Diamond published evidence of anatomical plasticity. In the 1960s–70s, work by Bach‑y‑Rita, Merzenich, and others expanded the field; Hubel & Wiesel’s kitten experiments illuminated critical‑period dynamics.

--- a/eval/verification/rag_gold_corpus_neuroplasticity/docs/NP03_synaptic_plasticity_basics.md
+++ b/eval/verification/rag_gold_corpus_neuroplasticity/docs/NP03_synaptic_plasticity_basics.md
@@ -1,0 +1,2 @@
+# Synaptic Plasticity — Core Ideas
+Synaptic plasticity is a key substrate of learning and memory. Mechanisms include changes in neurotransmitter release, receptor density (AMPA/NMDA), and receptor conductance via phosphorylation. Calcium influx through NMDA receptors is pivotal; downstream kinases (e.g., CaMKII, PKA) promote spine growth and receptor insertion. Homeostatic processes like synaptic scaling and metaplasticity maintain network stability.

--- a/eval/verification/rag_gold_corpus_neuroplasticity/docs/NP04_ltp_ltd.md
+++ b/eval/verification/rag_gold_corpus_neuroplasticity/docs/NP04_ltp_ltd.md
@@ -1,0 +1,2 @@
+# LTP & LTD
+Long‑term potentiation (LTP) and long‑term depression (LTD) are enduring bidirectional changes in synaptic efficacy. LTP was first reported in 1973 by Lømo and Bliss in hippocampal pathways. Strong postsynaptic depolarization and elevated Ca²⁺ favor LTP; weaker or patterned calcium signals can induce LTD. Stabilization correlates with structural changes (boutons, spines, PSD proteins like PSD‑95 and Homer1c) and astrocyte signaling.

--- a/eval/verification/rag_gold_corpus_neuroplasticity/docs/NP05_structural_vs_functional.md
+++ b/eval/verification/rag_gold_corpus_neuroplasticity/docs/NP05_structural_vs_functional.md
@@ -1,0 +1,2 @@
+# Structural vs Functional Plasticity
+Structural plasticity: alterations in connections, grey‑matter proportion, and sometimes adult neurogenesis (robust in animal models; not convincingly demonstrated in humans). Functional plasticity: reassignment or reweighting of functions across circuits via patterns such as homologous area adaptation, map expansion, cross‑modal reassignment, and compensatory masquerade.

--- a/eval/verification/rag_gold_corpus_neuroplasticity/docs/NP06_applications_rehab.md
+++ b/eval/verification/rag_gold_corpus_neuroplasticity/docs/NP06_applications_rehab.md
@@ -1,0 +1,2 @@
+# Applications — Rehabilitation
+Neuroplasticity underpins recovery from brain injury and is leveraged in therapies like constraint‑induced movement therapy, functional electrical stimulation, treadmill training with body‑weight support, virtual‑reality therapy, and robot‑assisted therapy. Evidence for specific mechanisms varies; clinical outcomes often correlate with experience‑dependent reorganization.

--- a/eval/verification/rag_gold_corpus_neuroplasticity/docs/NP07_phantom_limb.md
+++ b/eval/verification/rag_gold_corpus_neuroplasticity/docs/NP07_phantom_limb.md
@@ -1,0 +1,2 @@
+# Phantom Limbs & Maladaptive Plasticity
+Between 60% and 80% of amputees experience phantom limb sensations. Remapping in somatosensory cortex may misattribute activity to the missing limb. Some studies associate phantom limb **pain** specifically with cortical reorganization (maladaptive plasticity), distinguishing it from referred sensations.

--- a/eval/verification/rag_gold_corpus_neuroplasticity/docs/NP08_chronic_pain.md
+++ b/eval/verification/rag_gold_corpus_neuroplasticity/docs/NP08_chronic_pain.md
@@ -1,0 +1,2 @@
+# Chronic Pain & Cortical Reorganization
+Prolonged nociceptive input can reorganize cortical maps (central sensitization). Chronic pain conditions (e.g., CRPS, low back pain, carpal tunnel syndrome) show altered somatotopy and sometimes reduced grey‑matter volume, changes that can resolve with successful treatment alongside symptom improvement.

--- a/eval/verification/rag_gold_corpus_neuroplasticity/docs/NP09_meditation_art_music.md
+++ b/eval/verification/rag_gold_corpus_neuroplasticity/docs/NP09_meditation_art_music.md
@@ -1,0 +1,2 @@
+# Meditation, Art, and Music
+Meditation practice has been linked to differences in cortical thickness and functional connectivity in regions involved in attention and affect regulation. Long‑term artistic training can modularize domain‑specific and domain‑general networks, increasing cognitive flexibility. Music‑supported therapy in stroke rehabilitation is associated with motor improvements and functional changes in orbitofrontal and other circuits.

--- a/eval/verification/rag_gold_corpus_neuroplasticity/docs/NP10_exercise_bdnf.md
+++ b/eval/verification/rag_gold_corpus_neuroplasticity/docs/NP10_exercise_bdnf.md
@@ -1,0 +1,2 @@
+# Exercise, BDNF, and Cognition
+Aerobic exercise elevates neurotrophic factors (BDNF, IGF‑1, VEGF) and is associated with improvements in executive function and hippocampal‑dependent memory. Consistent training correlates with increased grey‑matter volume in prefrontal cortex and hippocampus and moderate changes in several other regions.

--- a/eval/verification/rag_gold_corpus_neuroplasticity/docs/NP11_sensory_loss_reassignment.md
+++ b/eval/verification/rag_gold_corpus_neuroplasticity/docs/NP11_sensory_loss_reassignment.md
@@ -1,0 +1,2 @@
+# Sensory Loss & Cross‑Modal Reassignment
+With deafness, auditory cortex often repurposes for visual and somatosensory tasks; behavioral effects include enhanced peripheral visual attention and specific motion‑change detection. With blindness, the visual cortex can participate in processing other modalities (e.g., sound localization, human echolocation), though some studies also note weakened performance for certain sensory judgments—effects are context‑dependent.

--- a/eval/verification/rag_gold_corpus_neuroplasticity/docs/NP12_multilingualism.md
+++ b/eval/verification/rag_gold_corpus_neuroplasticity/docs/NP12_multilingualism.md
@@ -1,0 +1,2 @@
+# Multilingualism
+Bilinguals and multilinguals often show structural and functional differences, including increased grey‑matter density in inferior parietal cortex and changes in white‑matter integrity. Early and active use correlate with stronger effects. These adaptations are interpreted as experience‑dependent plasticity supporting language control and cognitive flexibility.

--- a/eval/verification/rag_gold_corpus_neuroplasticity/docs/NP13_depression_psychoplastogens.md
+++ b/eval/verification/rag_gold_corpus_neuroplasticity/docs/NP13_depression_psychoplastogens.md
@@ -1,0 +1,2 @@
+# Depression & Rapid‑Acting Treatments
+A neuroplasticity perspective helps explain why classic monoaminergic antidepressants act slowly. Rapid‑acting agents (e.g., ketamine) can produce fast, durable antidepressant effects, plausibly via synaptogenesis and network connectivity restoration. The term “psychoplastogen” has been proposed for compounds that rapidly promote plasticity with therapeutic benefit.

--- a/eval/verification/rag_gold_corpus_neuroplasticity/docs/NP14_cochlear_implants_sensitive_period.md
+++ b/eval/verification/rag_gold_corpus_neuroplasticity/docs/NP14_cochlear_implants_sensitive_period.md
@@ -1,0 +1,2 @@
+# Cochlear Implants & Sensitive Periods
+Auditory development exhibits sensitive periods: in prelingually deaf children, early cochlear implantation (roughly within the first 2–4 years of life) tends to enable typical language acquisition by engaging plastic developmental windows in auditory pathways.

--- a/eval/verification/rag_gold_corpus_neuroplasticity/docs/NP15_conflict_range_example.md
+++ b/eval/verification/rag_gold_corpus_neuroplasticity/docs/NP15_conflict_range_example.md
@@ -1,0 +1,2 @@
+# Designed Conflict — Phantom Limb Prevalence
+Some summaries report “about 60%” of amputees experience phantom limb sensations, while others report “as high as 80%.” Both values appear in the literature, reflecting study/population differences. When asked for a single figure, a robust answer should acknowledge the reported **range (60–80%)** and uncertainty.

--- a/eval/verification/rag_gold_corpus_neuroplasticity/questions.yaml
+++ b/eval/verification/rag_gold_corpus_neuroplasticity/questions.yaml
@@ -1,0 +1,105 @@
+meta:
+  theme: Neuroplasticity (gold corpus)
+  source: Derived from Neuroplasticity.md upload
+  version: v1.0
+questions:
+- id: Q01
+  type: direct
+  question: Define neuroplasticity in one sentence.
+  gold_doc: NP01_definition_scope.md
+- id: Q02
+  type: direct
+  question: Who first reported long-term potentiation (LTP) and in what year?
+  gold_doc: NP04_ltp_ltd.md
+- id: Q03
+  type: direct
+  question: Name two cellular mechanisms that underlie synaptic plasticity.
+  gold_doc: NP03_synaptic_plasticity_basics.md
+- id: Q04
+  type: direct
+  question: List two therapy modalities that leverage neuroplasticity in stroke or brain-injury rehab.
+  gold_doc: NP06_applications_rehab.md
+- id: Q05
+  type: direct
+  question: Which neurotrophic factors increase with aerobic exercise and what domains of cognition often
+    improve?
+  gold_doc: NP10_exercise_bdnf.md
+- id: Q06
+  type: ambiguous
+  question: Tell me about plasticity from training.
+  gold_doc: NP09_meditation_art_music.md
+  clarify: Do you mean meditation, artistic training, music therapy, or physical exercise?
+- id: Q07
+  type: ambiguous
+  question: Explain sensory reassignment.
+  gold_doc: NP11_sensory_loss_reassignment.md
+  clarify: Should I focus on deafness, blindness, or human echolocation?
+- id: Q08
+  type: synthesis
+  question: Contrast structural and functional plasticity and give one example of each.
+  gold_docs:
+  - NP05_structural_vs_functional.md
+  - NP03_synaptic_plasticity_basics.md
+- id: Q09
+  type: synthesis
+  question: How do meditation and aerobic exercise each relate to brain plasticity?
+  gold_docs:
+  - NP09_meditation_art_music.md
+  - NP10_exercise_bdnf.md
+- id: Q10
+  type: synthesis
+  question: Summarize the sensitive period concept using the cochlear implant case and connect it to functional
+    reassignment.
+  gold_docs:
+  - NP14_cochlear_implants_sensitive_period.md
+  - NP11_sensory_loss_reassignment.md
+- id: Q11
+  type: conflict
+  question: What proportion of amputees experience phantom limb sensations?
+  gold_docs:
+  - NP07_phantom_limb.md
+  - NP15_conflict_range_example.md
+  note: "Expect a range (60\u201380%) with caveat."
+- id: Q12
+  type: freshness
+  question: What is the most up-to-date perspective on adult neurogenesis in humans from this corpus?
+  gold_doc: NP05_structural_vs_functional.md
+  note: Answer should reflect 'not convincingly demonstrated in humans' in this corpus.
+- id: Q13
+  type: direct
+  question: Name two homeostatic processes that stabilize neural network activity during plastic changes.
+  gold_doc: NP03_synaptic_plasticity_basics.md
+- id: Q14
+  type: direct
+  question: Which proteins correlate with structural stabilization after LTP?
+  gold_doc: NP04_ltp_ltd.md
+- id: Q15
+  type: direct
+  question: Give one cognitive benefit observed in multilinguals and one neural correlate.
+  gold_doc: NP12_multilingualism.md
+- id: Q16
+  type: multiturn
+  question: Discuss how plasticity explains recovery after brain injury.
+  gold_doc: NP06_applications_rehab.md
+  followups:
+  - Name one therapy and the likely mechanism.
+  - What evidence or limitations are noted?
+- id: Q17
+  type: synthesis
+  question: Relate chronic pain and phantom limb phenomena to cortical map reorganization.
+  gold_docs:
+  - NP08_chronic_pain.md
+  - NP07_phantom_limb.md
+- id: Q18
+  type: direct
+  question: "Mention two key 20th\u2011century figures or experiments that shaped modern views on plasticity."
+  gold_doc: NP02_history_milestones.md
+- id: Q19
+  type: direct
+  question: Define metaplasticity in one sentence.
+  gold_doc: NP03_synaptic_plasticity_basics.md
+- id: Q20
+  type: direct
+  question: What term has been proposed for compounds that rapidly promote plasticity with therapeutic
+    benefit for depression?
+  gold_doc: NP13_depression_psychoplastogens.md

--- a/pytest.ini
+++ b/pytest.ini
@@ -17,3 +17,4 @@ markers =
     integration: Integration tests
     slow: Slow running tests
     network: Tests that require network access
+asyncio_mode = auto

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -5,6 +5,7 @@ pytest-mock>=3.10.0
 pytest-xdist>=3.0.0  # For parallel test execution
 pytest-html>=3.1.0   # For HTML test reports
 pytest-asyncio>=1.0.0  # Async test support
+faiss-cpu>=1.7.4       # Required for FAISS-based indexing tests
 
 # Mocking and fixtures
 responses>=0.23.0    # For mocking HTTP requests
@@ -22,4 +23,3 @@ faker>=15.0.0        # Generate fake test data
 coverage>=7.0.0
 httpx
 anyio
-pytest-asyncio

--- a/run_rag_verification.py
+++ b/run_rag_verification.py
@@ -1,0 +1,611 @@
+#!/usr/bin/env python3
+"""Harness script to verify RAG/MCP stack against gold corpus."""
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import shlex
+import shutil
+import subprocess
+import sys
+from collections.abc import Iterable
+from pathlib import Path
+from typing import List, Sequence
+
+import yaml
+
+
+SUPPORTED_DIRECT_TYPES = {"direct", "synthesis", "conflict", "freshness"}
+SUPPORTED_MULTI_TYPES = {"ambiguous", "multiturn"}
+CITATION_PATTERN = re.compile(r"NP\d{2}")
+SUMMARY_LINE_TEMPLATE = "{status:<5}  {qid:<4} {note}"
+
+
+class CommandError(RuntimeError):
+    """Raised when a subprocess invocation fails."""
+
+
+def markdown_to_pdf(markdown_path: Path, pdf_path: Path) -> None:
+    """Render a markdown text file into a minimal PDF document."""
+
+    text = markdown_path.read_text(encoding="utf-8")
+    lines = text.splitlines() or [""]
+
+    def _escape_pdf_text(s: str) -> str:
+        return s.replace("\\", "\\\\").replace("(", "\\(").replace(")", "\\)")
+
+    content_lines = [
+        "BT",
+        "/F1 12 Tf",
+        "12 TL",
+        "1 0 0 1 72 720 Tm",
+    ]
+    for line in lines:
+        content_lines.append(f"({_escape_pdf_text(line.rstrip())}) Tj")
+        content_lines.append("T*")
+    content_lines.append("ET")
+    stream = "\n".join(content_lines) + "\n"
+    stream_bytes = stream.encode("utf-8")
+
+    pdf_parts: list[bytes] = [b"%PDF-1.4\n"]
+    offsets = [0]
+    current_offset = len(pdf_parts[0])
+
+    def add_object(index: int, body: str) -> None:
+        nonlocal current_offset
+        obj = f"{index} 0 obj\n{body}\nendobj\n".encode("utf-8")
+        offsets.append(current_offset)
+        pdf_parts.append(obj)
+        current_offset += len(obj)
+
+    add_object(1, "<< /Type /Catalog /Pages 2 0 R >>")
+    add_object(2, "<< /Type /Pages /Kids [3 0 R] /Count 1 >>")
+    add_object(
+        3,
+        "<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Contents 4 0 R "
+        "/Resources << /Font << /F1 5 0 R >> >> >>",
+    )
+    add_object(
+        4,
+        "<< /Length {length} >>\nstream\n{stream}endstream".format(
+            length=len(stream_bytes), stream=stream
+        ),
+    )
+    add_object(5, "<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>")
+
+    xref_offset = current_offset
+    xref_entries = ["0000000000 65535 f \n"]
+    for offset in offsets[1:]:
+        xref_entries.append(f"{offset:010d} 00000 n \n")
+    xref_section = "xref\n0 {count}\n{entries}".format(
+        count=len(offsets), entries="".join(xref_entries)
+    )
+    pdf_parts.append(xref_section.encode("utf-8"))
+    trailer = (
+        "trailer\n"
+        f"<< /Size {len(offsets)} /Root 1 0 R >>\n"
+        "startxref\n"
+        f"{xref_offset}\n"
+        "%%EOF\n"
+    )
+    pdf_parts.append(trailer.encode("utf-8"))
+
+    pdf_path.parent.mkdir(parents=True, exist_ok=True)
+    pdf_path.write_bytes(b"".join(pdf_parts))
+
+
+def prepare_pdf_corpus(markdown_dir: Path, output_dir: Path) -> List[Path]:
+    """Convert a directory of markdown documents into PDFs for indexing."""
+
+    markdown_files = sorted(markdown_dir.glob("*.md"))
+    if not markdown_files:
+        raise FileNotFoundError(
+            f"No markdown documents found in {markdown_dir} to build the index"
+        )
+
+    pdf_paths: List[Path] = []
+    for md_path in markdown_files:
+        pdf_path = output_dir / f"{md_path.stem}.pdf"
+        markdown_to_pdf(md_path, pdf_path)
+        pdf_paths.append(pdf_path)
+    return pdf_paths
+
+
+def parse_args(argv: Sequence[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Run verification against the neuroplasticity gold corpus."
+    )
+    parser.add_argument(
+        "--verbose",
+        action="store_true",
+        help="Echo commands before executing them.",
+    )
+    parser.add_argument(
+        "--keep-index",
+        action="store_true",
+        help="Do not delete ./tmp_index after verification completes.",
+    )
+    parser.add_argument(
+        "--index",
+        default="storage",
+        help=(
+            "Directory containing FAISS index folders. Defaults to ./storage inside the"
+            " repository root."
+        ),
+    )
+    return parser.parse_args(argv)
+
+
+def resolve_script(repo_root: Path, *candidates: str) -> Path:
+    """Resolve a script path by checking a sequence of candidate relative paths."""
+
+    for candidate in candidates:
+        script_path = repo_root / candidate
+        if script_path.exists():
+            return script_path
+    raise FileNotFoundError(
+        f"Unable to locate script. Checked: {', '.join(str(repo_root / c) for c in candidates)}"
+    )
+
+
+def run_command(
+    command: Sequence[str], *, verbose: bool = False, cwd: Path | None = None
+) -> subprocess.CompletedProcess[str]:
+    """Execute a command, returning the completed process."""
+
+    if verbose:
+        print("$", " ".join(shlex.quote(part) for part in command))
+    result = subprocess.run(
+        command,
+        cwd=str(cwd) if cwd else None,
+        capture_output=True,
+        text=True,
+    )
+    return result
+
+
+def load_questions(path: Path) -> List[dict]:
+    with path.open("r", encoding="utf-8") as f:
+        data = yaml.safe_load(f)
+    if not isinstance(data, Iterable):
+        raise ValueError(f"questions.yaml must contain a list, found {type(data)!r}")
+    questions: List[dict] = []
+    for entry in data:
+        if not isinstance(entry, dict):
+            raise ValueError("Each question entry must be a mapping")
+        questions.append(entry)
+    return questions
+
+
+def normalize_expected_docs(entry: dict) -> List[str]:
+    for key in ("gold_docs", "gold_doc", "gold_documents", "gold"):
+        if key in entry and entry[key] is not None:
+            value = entry[key]
+            if isinstance(value, str):
+                return [value.strip()]
+            if isinstance(value, Iterable):
+                docs: List[str] = []
+                for item in value:
+                    if isinstance(item, str):
+                        docs.append(item.strip())
+                return docs
+    return []
+
+
+def normalize_followups(entry: dict) -> List[str]:
+    followups: List[str] = []
+    for key in ("clarify", "followups"):
+        if key not in entry or entry[key] is None:
+            continue
+        value = entry[key]
+        if isinstance(value, str):
+            if value.strip():
+                followups.append(value.strip())
+        elif isinstance(value, Iterable):
+            for item in value:
+                if isinstance(item, str) and item.strip():
+                    followups.append(item.strip())
+    return followups
+
+
+def extract_citations(text: str) -> List[str]:
+    return sorted(set(CITATION_PATTERN.findall(text)))
+
+
+def ensure_tmp_index(tmp_index: Path) -> None:
+    if tmp_index.exists():
+        shutil.rmtree(tmp_index)
+    tmp_index.mkdir(parents=True, exist_ok=True)
+
+
+def build_index(
+    script_path: Path,
+    corpus_docs: Path,
+    *,
+    verbose: bool,
+    cwd: Path,
+    repo_root: Path,
+    tmp_index: Path,
+    index_key: str,
+    index_root: Path,
+) -> tuple[Path, list[Path], Path]:
+    pdf_dir = tmp_index / "pdf_corpus"
+    prepare_pdf_corpus(corpus_docs, pdf_dir)
+
+    chunks_dir = repo_root / "data_processed"
+    index_root.mkdir(parents=True, exist_ok=True)
+    command = [
+        sys.executable,
+        str(script_path),
+        index_key,
+        "--input-dir",
+        str(pdf_dir),
+        "--chunks-dir",
+        str(chunks_dir),
+        "--index-dir",
+        str(index_root),
+        "--no-gpu",
+    ]
+    result = run_command(command, verbose=verbose, cwd=cwd)
+    if result.returncode != 0:
+        raise CommandError(
+            f"Index build failed with code {result.returncode}: {result.stderr.strip()}"
+        )
+
+    chunk_path = chunks_dir / f"lc_chunks_{index_key}.jsonl"
+    index_paths = sorted(index_root.glob(f"faiss_{index_key}__*"))
+    return chunk_path, index_paths, pdf_dir
+
+
+def run_lc_ask_query(
+    script_path: Path,
+    query: str,
+    *,
+    index_key: str,
+    index_root: Path,
+    verbose: bool,
+    cwd: Path,
+) -> subprocess.CompletedProcess[str]:
+    command = [
+        sys.executable,
+        str(script_path),
+        query,
+        "--key",
+        index_key,
+        "--index",
+        str(index_root),
+    ]
+    return run_command(command, verbose=verbose, cwd=cwd)
+
+
+def run_multi_agent_query(
+    script_path: Path,
+    query: str,
+    *,
+    index_key: str,
+    index_root: Path,
+    verbose: bool,
+    cwd: Path,
+) -> subprocess.CompletedProcess[str]:
+    # ``script_path`` is resolved to ensure the source file exists, but Typer
+    # CLIs must be invoked via the module path for package-relative imports to
+    # succeed.
+    if not script_path.exists():
+        raise FileNotFoundError(f"multi_agent CLI not found at {script_path}")
+
+    command = [
+        sys.executable,
+        "-m",
+        "src.cli.multi_agent",
+        query,
+        "--key",
+        index_key,
+        "--index",
+        str(index_root),
+    ]
+    return run_command(command, verbose=verbose, cwd=cwd)
+
+
+def evaluate_answer(
+    qid: str,
+    stdout: str,
+    expected_docs: Sequence[str],
+    *,
+    question_type: str,
+) -> tuple[bool, str]:
+    citations = extract_citations(stdout)
+    citations_set = set(citations)
+    missing_docs = [doc for doc in expected_docs if doc not in citations_set]
+    pass_check = not missing_docs
+    notes: List[str] = []
+
+    if expected_docs:
+        if pass_check:
+            notes.append("cites " + ", ".join(expected_docs))
+        else:
+            notes.append(
+                "missing citations for " + ", ".join(missing_docs)
+            )
+
+    if question_type == "conflict" and qid.upper() == "Q11":
+        required = {"NP07", "NP15"}
+        has_required = required.issubset(citations_set)
+        has_range = "60" in stdout and "80" in stdout
+        if not has_required or not has_range:
+            pass_check = False
+            if not has_required:
+                notes.append("requires NP07 and NP15 citations")
+            if not has_range:
+                notes.append("missing numeric range 60-80")
+    if question_type == "freshness" and qid.upper() == "Q12":
+        phrase_present = "not convincingly demonstrated" in stdout.lower()
+        cites_np05 = "NP05" in citations_set
+        if not (phrase_present and cites_np05):
+            pass_check = False
+            if not phrase_present:
+                notes.append("missing 'not convincingly demonstrated'")
+            if not cites_np05:
+                notes.append("missing NP05 citation")
+
+    if not notes:
+        if citations:
+            notes.append("cites " + ", ".join(citations))
+        else:
+            notes.append("no citations detected")
+
+    return pass_check, "; ".join(notes)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = parse_args(argv or sys.argv[1:])
+    repo_root = Path(__file__).resolve().parent
+    cwd = repo_root
+    index_key = "rag_verification"
+    index_root = Path(args.index)
+    if not index_root.is_absolute():
+        index_root = (repo_root / index_root).resolve()
+
+    try:
+        lc_build = resolve_script(
+            repo_root,
+            "lc_build_index.py",
+            "src/langchain/lc_build_index.py",
+        )
+        lc_ask = resolve_script(
+            repo_root,
+            "lc_ask.py",
+            "src/langchain/lc_ask.py",
+        )
+        multi_agent = resolve_script(
+            repo_root,
+            "multi_agent.py",
+            "src/cli/multi_agent.py",
+        )
+    except FileNotFoundError as exc:
+        print(str(exc), file=sys.stderr)
+        return 1
+
+    corpus_dir = repo_root / "eval/verification" / "rag_gold_corpus_neuroplasticity" / "docs"
+    questions_path = repo_root / "eval/verification" / "rag_gold_corpus_neuroplasticity" / "questions.yaml"
+    tmp_index = repo_root / "tmp_index"
+
+    if not corpus_dir.exists():
+        print(f"Corpus directory not found: {corpus_dir}", file=sys.stderr)
+        return 1
+    if not questions_path.exists():
+        print(f"Questions file not found: {questions_path}", file=sys.stderr)
+        return 1
+
+    ensure_tmp_index(tmp_index)
+    generated_chunk: Path | None = None
+    generated_indexes: list[Path] = []
+    pdf_dir: Path | None = None
+    try:
+        generated_chunk, generated_indexes, pdf_dir = build_index(
+            lc_build,
+            corpus_dir,
+            verbose=args.verbose,
+            cwd=cwd,
+            repo_root=repo_root,
+            tmp_index=tmp_index,
+            index_key=index_key,
+            index_root=index_root,
+        )
+    except CommandError as exc:
+        print(str(exc), file=sys.stderr)
+        return 1
+
+    questions = load_questions(questions_path)
+    log_records: List[dict] = []
+    summary_lines: List[str] = []
+    all_passed = True
+
+    for entry in questions:
+        qid = str(entry.get("id") or entry.get("qid") or "?").strip() or "?"
+        question_text = (
+            str(entry.get("question") or entry.get("query") or "").strip()
+        )
+        question_type = str(entry.get("type") or "").strip().lower()
+        expected_docs = [doc.upper() for doc in normalize_expected_docs(entry)]
+        followups = normalize_followups(entry)
+
+        if not question_text:
+            summary_lines.append(
+                SUMMARY_LINE_TEMPLATE.format(
+                    status="FAIL", qid=qid, note="missing question text"
+                )
+            )
+            log_records.append(
+                {
+                    "qid": qid,
+                    "query": question_text,
+                    "stdout": "",
+                    "pass": False,
+                    "notes": "missing question text",
+                }
+            )
+            all_passed = False
+            continue
+
+        stdout_segments: List[str] = []
+        final_stdout = ""
+
+        if question_type in SUPPORTED_DIRECT_TYPES:
+            result = run_lc_ask_query(
+                lc_ask,
+                question_text,
+                index_key=index_key,
+                index_root=index_root,
+                verbose=args.verbose,
+                cwd=cwd,
+            )
+            if result.returncode != 0:
+                note = f"lc_ask.py failed: {result.stderr.strip()}"
+                summary_lines.append(
+                    SUMMARY_LINE_TEMPLATE.format(status="FAIL", qid=qid, note=note)
+                )
+                log_records.append(
+                    {
+                        "qid": qid,
+                        "query": question_text,
+                        "stdout": result.stdout,
+                        "pass": False,
+                        "notes": note,
+                    }
+                )
+                all_passed = False
+                continue
+            final_stdout = result.stdout
+            stdout_segments.append(result.stdout)
+        elif question_type in SUPPORTED_MULTI_TYPES:
+            current_query = question_text
+            outputs: List[str] = []
+            result = run_multi_agent_query(
+                multi_agent,
+                current_query,
+                index_key=index_key,
+                index_root=index_root,
+                verbose=args.verbose,
+                cwd=cwd,
+            )
+            if result.returncode != 0:
+                note = f"multi_agent.py failed: {result.stderr.strip()}"
+                summary_lines.append(
+                    SUMMARY_LINE_TEMPLATE.format(status="FAIL", qid=qid, note=note)
+                )
+                log_records.append(
+                    {
+                        "qid": qid,
+                        "query": current_query,
+                        "stdout": result.stdout,
+                        "pass": False,
+                        "notes": note,
+                    }
+                )
+                all_passed = False
+                continue
+            outputs.append(result.stdout)
+
+            for follow in followups:
+                current_query = f"{current_query}\n{follow}"
+                follow_result = run_multi_agent_query(
+                    multi_agent,
+                    current_query,
+                    index_key=index_key,
+                    index_root=index_root,
+                    verbose=args.verbose,
+                    cwd=cwd,
+                )
+                if follow_result.returncode != 0:
+                    note = f"multi_agent.py follow-up failed: {follow_result.stderr.strip()}"
+                    summary_lines.append(
+                        SUMMARY_LINE_TEMPLATE.format(
+                            status="FAIL", qid=qid, note=note
+                        )
+                    )
+                    log_records.append(
+                        {
+                            "qid": qid,
+                            "query": current_query,
+                            "stdout": follow_result.stdout,
+                            "pass": False,
+                            "notes": note,
+                        }
+                    )
+                    all_passed = False
+                    break
+                outputs.append(follow_result.stdout)
+            else:
+                final_stdout = outputs[-1] if outputs else ""
+                stdout_segments.extend(outputs)
+                # fall through to evaluation
+                pass
+
+            if not final_stdout:
+                # follow-up loop may break on error
+                continue
+        else:
+            note = f"unsupported question type '{question_type}'"
+            summary_lines.append(
+                SUMMARY_LINE_TEMPLATE.format(status="FAIL", qid=qid, note=note)
+            )
+            log_records.append(
+                {
+                    "qid": qid,
+                    "query": question_text,
+                    "stdout": "",
+                    "pass": False,
+                    "notes": note,
+                }
+            )
+            all_passed = False
+            continue
+
+        passed, note = evaluate_answer(
+            qid,
+            final_stdout,
+            expected_docs,
+            question_type=question_type,
+        )
+        status = "PASS" if passed else "FAIL"
+        summary_lines.append(
+            SUMMARY_LINE_TEMPLATE.format(status=status, qid=qid, note=note)
+        )
+        log_records.append(
+            {
+                "qid": qid,
+                "query": question_text,
+                "stdout": "\n---\n".join(stdout_segments),
+                "pass": passed,
+                "notes": note,
+            }
+        )
+        all_passed = all_passed and passed
+
+    logs_dir = repo_root / "logs"
+    logs_dir.mkdir(parents=True, exist_ok=True)
+    logs_path = logs_dir / "rag_verification.jsonl"
+    with logs_path.open("w", encoding="utf-8") as log_file:
+        for record in log_records:
+            log_file.write(json.dumps(record, ensure_ascii=False) + "\n")
+
+    for line in summary_lines:
+        print(line)
+
+    if not args.keep_index:
+        if generated_chunk and generated_chunk.exists():
+            generated_chunk.unlink()
+        for index_path in generated_indexes:
+            if index_path.exists():
+                shutil.rmtree(index_path)
+        if pdf_dir and pdf_dir.exists():
+            shutil.rmtree(pdf_dir)
+        if tmp_index.exists():
+            shutil.rmtree(tmp_index)
+
+    return 0 if all_passed else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/cli/multi_agent.py
+++ b/src/cli/multi_agent.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 
 import asyncio
+from pathlib import Path
+
 import typer
 
 from ..core.llm import LLMFactory
@@ -15,13 +17,27 @@ app = typer.Typer(add_completion=False)
 def ask(
     question: str = typer.Argument(..., help="Question to pass to the agent"),
     key: str = typer.Option("default", "--key", "-k", help="FAISS index key"),
+    index: Path | None = typer.Option(
+        None,
+        "--index",
+        help=(
+            "Directory containing FAISS index folders. Defaults to ./storage inside the"
+            " project root."
+        ),
+    ),
     mcp: str | None = typer.Option(
         None, "--mcp", help="Path to MCP server executable to register tools from"
     ),
 ) -> None:
     """Run the agent loop with RAG and optional MCP tools."""
     registry = ToolRegistry()
-    registry.register(create_rag_retrieve_tool(key))
+    repo_root = Path(__file__).resolve().parents[2]
+    if index is None:
+        index_dir = repo_root / "storage"
+    else:
+        index_dir = index if index.is_absolute() else (repo_root / index).resolve()
+
+    registry.register(create_rag_retrieve_tool(key, index_dir=index_dir))
     if mcp:
         asyncio.run(registry.register_mcp_server(mcp))
 

--- a/src/config/settings.py
+++ b/src/config/settings.py
@@ -149,13 +149,14 @@ class AppConfig:
     def _determine_parallel_workers(self) -> int:
         """Resolve the default parallel worker count from env or system state."""
 
-        env_value = os.getenv("PARALLEL_WORKERS_COUNT", os.cpu_count())
-
-        if env_value is not None:
+        for env_var in ("RAG_PARALLEL_WORKERS", "PARALLEL_WORKERS_COUNT"):
+            env_value = os.getenv(env_var)
+            if env_value is None or str(env_value).strip() == "":
+                continue
             try:
                 return self._clamp_parallel_workers(int(env_value))
             except (TypeError, ValueError):
-                pass
+                continue
 
         cpu_count = os.cpu_count() or 1
         return self._clamp_parallel_workers(cpu_count)

--- a/src/core/retriever.py
+++ b/src/core/retriever.py
@@ -108,16 +108,30 @@ class RetrieverConfig:
 class RetrieverFactory:
     """Factory for creating various types of retrievers with consistent configuration."""
 
-    def __init__(self, root_dir: Optional[Path] = None):
-        """Initialize the factory with root directory."""
+    def __init__(
+        self,
+        root_dir: Optional[Path] = None,
+        storage_dir: Optional[Path] = None,
+    ):
+        """Initialize the factory with root directory and optional storage override."""
+
         if root_dir is None:
-            # Calculate root relative to this file (two levels up)
-            root_dir = Path(__file__).parent.parent.parent
+            root_dir = Path(__file__).resolve().parents[2]
+        else:
+            root_dir = Path(root_dir)
         self.root_dir = root_dir
+
+        if storage_dir is None:
+            storage_path = self.root_dir / "storage"
+        else:
+            storage_path = Path(storage_dir)
+            if not storage_path.is_absolute():
+                storage_path = (self.root_dir / storage_path).resolve()
+        self.storage_dir = storage_path
 
     def _get_storage_path(self, key: str) -> Path:
         """Get the storage path for a given collection key."""
-        return self.root_dir / "storage" / f"faiss_{key}"
+        return self.storage_dir / f"faiss_{key}"
 
     def _load_embeddings(self, model_name: str) -> HuggingFaceEmbeddings:
         """Load and return the embedding model."""

--- a/src/langchain/__init__.py
+++ b/src/langchain/__init__.py
@@ -5,5 +5,7 @@ This package contains tools for generating content using LangChain,
 including outline processing, batch processing, and content merging.
 """
 
+from . import _embeddings_compat  # noqa: F401
+
 __version__ = "1.0.0"
 __author__ = "LangChain Content Generation Team"

--- a/src/langchain/_embeddings_compat.py
+++ b/src/langchain/_embeddings_compat.py
@@ -1,0 +1,35 @@
+"""Compatibility helpers for LangChain embedding interfaces."""
+
+from __future__ import annotations
+
+from typing import Iterable, Sequence
+
+from langchain_core.embeddings import Embeddings
+from langchain_community.vectorstores.faiss import FAISS
+
+
+def _call_embedder(embedding_fn, method: str, *args):
+    if isinstance(embedding_fn, Embeddings):
+        return getattr(embedding_fn, method)(*args)
+    if hasattr(embedding_fn, method):
+        return getattr(embedding_fn, method)(*args)
+    if callable(embedding_fn):
+        return embedding_fn(*args)
+    raise TypeError(
+        f"Embedding function must implement '{method}' or be callable; got {type(embedding_fn)}"
+    )
+
+
+def _embed_query(self: FAISS, text: str) -> Sequence[float]:  # type: ignore[override]
+    return _call_embedder(self.embedding_function, "embed_query", text)
+
+
+def _embed_documents(self: FAISS, texts: Iterable[str]):  # type: ignore[override]
+    return _call_embedder(self.embedding_function, "embed_documents", list(texts))
+
+
+if not getattr(FAISS, "_ragwriter_embed_patch", False):
+    FAISS._embed_query = _embed_query  # type: ignore[assignment]
+    FAISS._embed_documents = _embed_documents  # type: ignore[assignment]
+    FAISS._ragwriter_embed_patch = True
+

--- a/src/langchain/faiss_utils.py
+++ b/src/langchain/faiss_utils.py
@@ -1,0 +1,20 @@
+"""LangChain-facing FAISS helpers exposing core utilities."""
+
+from src.core.faiss_utils import (
+    clone_index_to_cpu,
+    clone_index_to_gpu,
+    ensure_cpu_index,
+    is_faiss_gpu_available,
+    set_faiss_threads,
+    try_index_cpu_to_gpu,
+)
+
+__all__ = [
+    "clone_index_to_cpu",
+    "clone_index_to_gpu",
+    "ensure_cpu_index",
+    "is_faiss_gpu_available",
+    "set_faiss_threads",
+    "try_index_cpu_to_gpu",
+]
+

--- a/src/tool/rag_tool.py
+++ b/src/tool/rag_tool.py
@@ -2,7 +2,8 @@
 
 from __future__ import annotations
 
-from typing import Any, Dict, List
+from pathlib import Path
+from typing import Any, Dict, List, Optional
 
 from langchain_core.documents import Document
 
@@ -10,7 +11,7 @@ from .base import Tool, ToolSpec
 from ..core.retriever import RetrieverFactory, RetrieverConfig
 
 
-def create_rag_retrieve_tool(key: str) -> Tool:
+def create_rag_retrieve_tool(key: str, index_dir: Optional[Path | str] = None) -> Tool:
     """Create a tool that retrieves documents from the local vector database.
 
     Parameters
@@ -19,7 +20,11 @@ def create_rag_retrieve_tool(key: str) -> Tool:
         Collection key used to locate the FAISS index.
     """
 
-    factory = RetrieverFactory()
+    storage_dir_path: Path | None = None
+    if index_dir is not None:
+        storage_dir_path = Path(index_dir)
+
+    factory = RetrieverFactory(storage_dir=storage_dir_path)
 
     def _run(
         query: str,

--- a/tests/unit/test_run_rag_verification.py
+++ b/tests/unit/test_run_rag_verification.py
@@ -1,0 +1,39 @@
+"""Tests for helper utilities in ``run_rag_verification``."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from run_rag_verification import parse_args, prepare_pdf_corpus
+
+
+def test_prepare_pdf_corpus_creates_pdfs(tmp_path: Path) -> None:
+    markdown_dir = tmp_path / "md"
+    markdown_dir.mkdir()
+    (markdown_dir / "sample.md").write_text("hello world\nsecond line", encoding="utf-8")
+
+    output_dir = tmp_path / "pdf"
+    pdf_paths = prepare_pdf_corpus(markdown_dir, output_dir)
+
+    assert len(pdf_paths) == 1
+    pdf_path = pdf_paths[0]
+    assert pdf_path.exists()
+    assert pdf_path.stat().st_size > 0
+
+
+def test_prepare_pdf_corpus_requires_markdown(tmp_path: Path) -> None:
+    output_dir = tmp_path / "pdf"
+    with pytest.raises(FileNotFoundError):
+        prepare_pdf_corpus(tmp_path, output_dir)
+
+
+def test_parse_args_accepts_index_override() -> None:
+    args = parse_args(["--index", "custom_storage"])
+    assert args.index == "custom_storage"
+
+
+def test_parse_args_defaults_index_to_storage() -> None:
+    args = parse_args([])
+    assert args.index == "storage"


### PR DESCRIPTION
## Summary
- convert verification corpus markdown into temporary PDFs and invoke lc_build_index with the current CLI contract
- adjust harness query execution to call lc_ask and multi_agent with the updated positional arguments and clean up generated artifacts
- add unit coverage for markdown-to-PDF conversion utilities used during index preparation
- allow overriding the FAISS storage directory in the verification harness and downstream CLIs while running multi-agent via the package module entry point

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68d2ded26978832cb47e19a6c9b04be7