### PR TITLE
Fix harness CLI invocation and corpus preparation

### DIFF
--- a/run_rag_verification.py
+++ b/run_rag_verification.py
@@ -1,0 +1,241 @@
+"""Utility harness for rebuilding RAG indices and running verification checks."""
+
+from __future__ import annotations
+
+import argparse
+import subprocess
+import sys
+from pathlib import Path
+from typing import Sequence
+
+
+def _pdf_escape(text: str) -> str:
+    return (
+        text.replace("\\", "\\\\")
+        .replace("(", "\\(")
+        .replace(")", "\\)")
+        .replace("\r", "")
+    )
+
+
+def _render_pdf_stream(text: str) -> bytes:
+    lines = text.split("\n")
+    if not lines:
+        lines = [""]
+
+    contents: list[str] = ["BT", "/F1 11 Tf", "72 720 Td"]
+    for index, line in enumerate(lines):
+        escaped = _pdf_escape(line)
+        if index == 0:
+            contents.append(f"({escaped}) Tj")
+        else:
+            contents.append("T*")
+            contents.append(f"({escaped}) Tj")
+    contents.append("ET")
+    return "\n".join(contents).encode("utf-8")
+
+
+def _build_pdf_bytes(stream: bytes) -> bytes:
+    header = b"%PDF-1.4\n%\xe2\xe3\xcf\xd3\n"
+    objects: list[tuple[int, bytes]] = [
+        (1, b"<< /Type /Catalog /Pages 2 0 R >>"),
+        (2, b"<< /Type /Pages /Kids [3 0 R] /Count 1 >>"),
+        (
+            3,
+            b"<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] "
+            b"/Contents 4 0 R /Resources << /Font << /F1 5 0 R >> >> >>",
+        ),
+        (4, b"<< /Length %d >>\nstream\n" % len(stream) + stream + b"\nendstream"),
+        (5, b"<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>"),
+    ]
+
+    parts: list[bytes] = [header]
+    offsets: list[int] = []
+    current = len(header)
+
+    for number, body in objects:
+        obj_bytes = f"{number} 0 obj\n".encode("ascii") + body + b"\nendobj\n"
+        parts.append(obj_bytes)
+        offsets.append(current)
+        current += len(obj_bytes)
+
+    body_bytes = b"".join(parts)
+    xref_offset = len(body_bytes)
+    size = len(objects) + 1
+
+    xref_lines = ["0000000000 65535 f \n"] + [
+        f"{offset:010d} 00000 n \n" for offset in offsets
+    ]
+    xref = ("xref\n0 {size}\n".format(size=size) + "".join(xref_lines)).encode("ascii")
+    trailer = (
+        "trailer\n<< /Size {size} /Root 1 0 R >>\nstartxref\n{xref}\n%%EOF\n".format(
+            size=size, xref=xref_offset
+        ).encode("ascii")
+    )
+
+    return body_bytes + xref + trailer
+
+
+def convert_markdown_to_pdfs(markdown_dir: Path, pdf_dir: Path) -> list[Path]:
+    markdown_dir = Path(markdown_dir)
+    pdf_dir = Path(pdf_dir)
+    pdf_dir.mkdir(parents=True, exist_ok=True)
+
+    pdf_paths: list[Path] = []
+    for md_path in sorted(markdown_dir.rglob("*.md")):
+        relative = md_path.relative_to(markdown_dir)
+        target = pdf_dir / relative.with_suffix(".pdf")
+        target.parent.mkdir(parents=True, exist_ok=True)
+        text = md_path.read_text(encoding="utf-8")
+        stream = _render_pdf_stream(text)
+        pdf_bytes = _build_pdf_bytes(stream)
+        target.write_bytes(pdf_bytes)
+        pdf_paths.append(target)
+
+    return pdf_paths
+
+
+def _run_subprocess(cmd: Sequence[str], *, env: dict[str, str] | None = None) -> None:
+    subprocess.run(list(cmd), check=True, text=True, env=env)
+
+
+def build_faiss_index(
+    *,
+    key: str,
+    pdf_dir: Path,
+    chunks_dir: Path,
+    index_dir: Path,
+    resume: bool = False,
+    keep_shards: bool = False,
+    env: dict[str, str] | None = None,
+) -> None:
+    pdf_dir = Path(pdf_dir)
+    chunks_dir = Path(chunks_dir)
+    index_dir = Path(index_dir)
+
+    cmd: list[str] = [
+        sys.executable,
+        "src/langchain/lc_build_index.py",
+        key,
+        "--input-dir",
+        str(pdf_dir),
+        "--chunks-dir",
+        str(chunks_dir),
+        "--index-dir",
+        str(index_dir),
+    ]
+    if resume:
+        cmd.append("--resume")
+    if keep_shards:
+        cmd.append("--keep-shards")
+
+    _run_subprocess(cmd, env=env)
+
+
+def run_lc_ask(
+    *,
+    question: str,
+    key: str,
+    chunks_dir: Path,
+    index_dir: Path,
+    embed_model: str,
+    env: dict[str, str] | None = None,
+) -> None:
+    cmd: list[str] = [
+        sys.executable,
+        "src/langchain/lc_ask.py",
+        question,
+        "--key",
+        key,
+        "--chunks-dir",
+        str(Path(chunks_dir)),
+        "--index-dir",
+        str(Path(index_dir)),
+        "--embed-model",
+        embed_model,
+    ]
+    _run_subprocess(cmd, env=env)
+
+
+def run_multi_agent(
+    *,
+    question: str,
+    key: str,
+    env: dict[str, str] | None = None,
+    mcp: str | None = None,
+) -> None:
+    cmd: list[str] = [
+        sys.executable,
+        "src/cli/multi_agent.py",
+        "ask",
+        question,
+        "--key",
+        key,
+    ]
+    if mcp:
+        cmd.extend(["--mcp", mcp])
+    _run_subprocess(cmd, env=env)
+
+
+def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--corpus-dir", type=Path, required=True)
+    parser.add_argument("--sandbox-dir", type=Path, default=Path(".rag_verification"))
+    parser.add_argument("--key", default="verification")
+    parser.add_argument("--embed-model", default="BAAI/bge-small-en-v1.5")
+    parser.add_argument("--resume", action="store_true")
+    parser.add_argument("--keep-shards", action="store_true")
+    parser.add_argument("--question", action="append", default=[])
+    parser.add_argument("--questions-file", type=Path)
+    parser.add_argument("--skip-multi-agent", action="store_true")
+    parser.add_argument("--mcp")
+    return parser.parse_args(argv)
+
+
+def _load_questions(args: argparse.Namespace) -> list[str]:
+    questions: list[str] = list(args.question)
+    if args.questions_file and args.questions_file.exists():
+        data = args.questions_file.read_text(encoding="utf-8").splitlines()
+        questions.extend(q for q in data if q.strip())
+    return questions
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = parse_args(argv)
+
+    sandbox = Path(args.sandbox_dir)
+    pdf_dir = sandbox / "pdfs"
+    chunks_dir = sandbox / "chunks"
+    index_dir = sandbox / "indices"
+
+    convert_markdown_to_pdfs(args.corpus_dir, pdf_dir)
+    build_faiss_index(
+        key=args.key,
+        pdf_dir=pdf_dir,
+        chunks_dir=chunks_dir,
+        index_dir=index_dir,
+        resume=args.resume,
+        keep_shards=args.keep_shards,
+    )
+
+    questions = _load_questions(args)
+    for question in questions:
+        run_lc_ask(
+            question=question,
+            key=args.key,
+            chunks_dir=chunks_dir,
+            index_dir=index_dir,
+            embed_model=args.embed_model,
+        )
+        if not args.skip_multi_agent:
+            run_multi_agent(
+                question=question,
+                key=args.key,
+                mcp=args.mcp,
+            )
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/unit/test_run_rag_verification.py
+++ b/tests/unit/test_run_rag_verification.py
@@ -1,0 +1,111 @@
+"""Regression tests for the RAG verification harness helpers."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import run_rag_verification as harness
+
+
+def test_convert_markdown_to_pdfs(tmp_path: Path) -> None:
+    """Markdown corpora should be rendered to PDFs in a target directory."""
+
+    corpus_dir = tmp_path / "corpus"
+    corpus_dir.mkdir()
+    (corpus_dir / "note-one.md").write_text("# Heading\n\nBody text", encoding="utf-8")
+    (corpus_dir / "note-two.md").write_text("Just some text", encoding="utf-8")
+
+    pdf_dir = tmp_path / "pdfs"
+    pdf_paths = harness.convert_markdown_to_pdfs(corpus_dir, pdf_dir)
+
+    assert sorted(p.name for p in pdf_paths) == ["note-one.pdf", "note-two.pdf"]
+    for pdf_path in pdf_paths:
+        data = pdf_path.read_bytes()
+        assert data.startswith(b"%PDF")
+
+
+def test_build_faiss_index_uses_expected_cli_flags(monkeypatch, tmp_path: Path) -> None:
+    """Ensure the FAISS builder is invoked with supported CLI options."""
+
+    invoked: dict[str, list[str]] = {}
+
+    def fake_run(cmd: list[str], *, env: dict[str, str] | None = None) -> None:
+        invoked["cmd"] = cmd
+        invoked["env"] = env or {}
+
+    monkeypatch.setattr(harness, "_run_subprocess", fake_run)
+
+    pdf_dir = tmp_path / "pdfs"
+    chunks_dir = tmp_path / "chunks"
+    index_dir = tmp_path / "storage"
+
+    harness.build_faiss_index(
+        key="neuroplasticity",
+        pdf_dir=pdf_dir,
+        chunks_dir=chunks_dir,
+        index_dir=index_dir,
+        resume=False,
+        keep_shards=False,
+    )
+
+    cmd = invoked["cmd"]
+    assert cmd[0].endswith("python") or cmd[0].endswith("python3") or cmd[0].endswith("pytest")
+    assert cmd[1:] == [
+        "src/langchain/lc_build_index.py",
+        "neuroplasticity",
+        "--input-dir",
+        str(pdf_dir),
+        "--chunks-dir",
+        str(chunks_dir),
+        "--index-dir",
+        str(index_dir),
+    ]
+
+
+def test_query_clis_match_expected_interfaces(monkeypatch, tmp_path: Path) -> None:
+    """The harness must call lc_ask and multi_agent with real CLI signatures."""
+
+    calls: list[list[str]] = []
+
+    def fake_run(cmd: list[str], *, env: dict[str, str] | None = None) -> None:
+        calls.append(cmd)
+
+    monkeypatch.setattr(harness, "_run_subprocess", fake_run)
+
+    chunks_dir = tmp_path / "chunks"
+    index_dir = tmp_path / "storage"
+
+    harness.run_lc_ask(
+        question="What is neuroplasticity?",
+        key="neuroplasticity",
+        chunks_dir=chunks_dir,
+        index_dir=index_dir,
+        embed_model="BAAI/bge-small-en-v1.5",
+    )
+    harness.run_multi_agent(
+        question="Summarize the findings",
+        key="neuroplasticity",
+    )
+
+    ask_cmd, agent_cmd = calls
+
+    assert ask_cmd[1:] == [
+        "src/langchain/lc_ask.py",
+        "What is neuroplasticity?",
+        "--key",
+        "neuroplasticity",
+        "--chunks-dir",
+        str(chunks_dir),
+        "--index-dir",
+        str(index_dir),
+        "--embed-model",
+        "BAAI/bge-small-en-v1.5",
+    ]
+
+    assert agent_cmd[1:] == [
+        "src/cli/multi_agent.py",
+        "ask",
+        "Summarize the findings",
+        "--key",
+        "neuroplasticity",
+    ]


### PR DESCRIPTION
## Summary
- add a markdown-to-PDF conversion pipeline so the verification harness feeds lc_build_index expected inputs
- update harness subprocess helpers to use supported lc_build_index, lc_ask, and multi_agent CLI signatures
- expose lightweight CLI orchestration for rebuilding indices and querying questions from a sandbox workspace

## Testing
- `pytest tests/unit/test_run_rag_verification.py`
- `ruff check run_rag_verification.py tests/unit/test_run_rag_verification.py`


------
https://chatgpt.com/codex/tasks/task_e_68d2e3170b30832c9617a9284a43fda1