### PR TITLE
Add index directory support to multi-agent RAG tooling

### DIFF
--- a/README.md
+++ b/README.md
@@ -799,7 +799,7 @@ over MCP:
 
 ```bash
 python -m src.cli.multi_agent "Find papers on transformers and call the time tool" \
-  --key default --mcp ./tools/mcp_server.py
+  --key default --mcp ./tools/mcp_server.py --index ./storage
 ```
 
 The command registers the `rag_retrieve` tool for vector search and loads any

--- a/run_rag_verification.py
+++ b/run_rag_verification.py
@@ -839,7 +839,7 @@ def build_question_invocation(
         key_flag = determine_flag(asker, ["--key"]) or "--key"
         if key_flag:
             base_args.extend([key_flag, index_key])
-        index_flag = determine_flag(asker, ["--index-dir", "--index"]) or "--index-dir"
+        index_flag = determine_flag(asker, ["--index", "--index-dir"]) or "--index-dir"
         if index_flag:
             base_args.extend([index_flag, str(index_dir)])
         chunks_flag = determine_flag(asker, ["--chunks-dir"]) or "--chunks-dir"
@@ -861,6 +861,9 @@ def build_question_invocation(
         key_flag = determine_flag(multi, ["--key", "-k"]) or "--key"
         if key_flag:
             base_args.extend([key_flag, index_key])
+        index_flag = determine_flag(multi, ["--index", "--index-dir"]) or "--index"
+        if index_flag:
+            base_args.extend([index_flag, str(index_dir)])
         command = build_question_command(script, question.prompt, base_args)
         if question.clarify:
             clarify_flag = determine_flag(

--- a/src/core/retriever.py
+++ b/src/core/retriever.py
@@ -108,16 +108,21 @@ class RetrieverConfig:
 class RetrieverFactory:
     """Factory for creating various types of retrievers with consistent configuration."""
 
-    def __init__(self, root_dir: Optional[Path] = None):
+    def __init__(
+        self,
+        root_dir: Optional[Path] = None,
+        storage_dir: Optional[Path] = None,
+    ):
         """Initialize the factory with root directory."""
         if root_dir is None:
             # Calculate root relative to this file (two levels up)
             root_dir = Path(__file__).parent.parent.parent
         self.root_dir = root_dir
+        self.storage_dir = storage_dir or (self.root_dir / "storage")
 
     def _get_storage_path(self, key: str) -> Path:
         """Get the storage path for a given collection key."""
-        return self.root_dir / "storage" / f"faiss_{key}"
+        return self.storage_dir / f"faiss_{key}"
 
     def _load_embeddings(self, model_name: str) -> HuggingFaceEmbeddings:
         """Load and return the embedding model."""

--- a/src/langchain/lc_ask.py
+++ b/src/langchain/lc_ask.py
@@ -210,8 +210,6 @@ def main():
     parser.add_argument("--json", dest="json_path", help="JSON job file containing 'question'")
     key_group = parser.add_mutually_exclusive_group(required=True)
     key_group.add_argument("--key", help="collection key used at index time")
-
-
     parser.add_argument("--embed-model", default="BAAI/bge-small-en-v1.5")
 
     parser.add_argument(
@@ -245,7 +243,6 @@ def main():
         help="Explicit path to chunk JSONL (overrides --chunks-dir lookup)",
     )
 
-    parser.add_argument("--embed-model", default="BAAI/bge-small-en-v1.5")
     parser.add_argument(
         "--input-dir",
         type=str,
@@ -255,13 +252,14 @@ def main():
 
     parser.add_argument(
         "--index-dir",
+        "--index",
+        dest="index_dir",
         type=str,
         default=str(ROOT / "storage"),
         help=(
             "Path to directory containing index directories (i.e., storage) not "
             "individual index directories, the collection of them"
         ),
-
     )
     args = parser.parse_args()
 

--- a/src/tool/rag_tool.py
+++ b/src/tool/rag_tool.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from pathlib import Path
 from typing import Any, Dict, List
 
 from langchain_core.documents import Document
@@ -10,16 +11,19 @@ from .base import Tool, ToolSpec
 from ..core.retriever import RetrieverFactory, RetrieverConfig
 
 
-def create_rag_retrieve_tool(key: str) -> Tool:
+def create_rag_retrieve_tool(key: str, index_dir: Path | None = None) -> Tool:
     """Create a tool that retrieves documents from the local vector database.
 
     Parameters
     ----------
     key:
         Collection key used to locate the FAISS index.
+    index_dir:
+        Optional path to a directory containing FAISS indexes. Defaults to the
+        repository ``storage`` directory when not provided.
     """
 
-    factory = RetrieverFactory()
+    factory = RetrieverFactory(storage_dir=index_dir)
 
     def _run(
         query: str,

--- a/tests/unit/test_cli_multi_agent.py
+++ b/tests/unit/test_cli_multi_agent.py
@@ -1,3 +1,5 @@
+from pathlib import Path
+
 from typer.testing import CliRunner
 
 from src.cli import multi_agent
@@ -19,8 +21,8 @@ def test_cli_invokes_agent_with_tools(monkeypatch):
     registry = DummyRegistry()
     monkeypatch.setattr(multi_agent, "ToolRegistry", lambda: registry)
 
-    def fake_create_tool(key: str):
-        fake_create_tool.called_with = key
+    def fake_create_tool(key: str, index_dir: Path | None = None):
+        fake_create_tool.called_with = (key, index_dir)
         return object()
 
     fake_create_tool.called_with = None
@@ -49,4 +51,39 @@ def test_cli_invokes_agent_with_tools(monkeypatch):
     assert "done" in result.stdout
     assert registry.registered_tool is not None
     assert registry.mcp_url == "server"
-    assert fake_create_tool.called_with == "paper"
+    assert fake_create_tool.called_with == (
+        "paper",
+        multi_agent.DEFAULT_INDEX_DIR,
+    )
+
+
+def test_cli_passes_custom_index(monkeypatch, tmp_path: Path):
+    registry = DummyRegistry()
+    monkeypatch.setattr(multi_agent, "ToolRegistry", lambda: registry)
+
+    captured: dict[str, object] = {}
+
+    def fake_create_tool(key: str, index_dir: Path | None = None):
+        captured["args"] = (key, index_dir)
+        return object()
+
+    monkeypatch.setattr(multi_agent, "create_rag_retrieve_tool", fake_create_tool)
+
+    mock_llm = object()
+
+    class FakeFactory:
+        def create_llm(self):
+            return ("backend", mock_llm)
+
+    monkeypatch.setattr(multi_agent, "LLMFactory", lambda: FakeFactory())
+    monkeypatch.setattr(multi_agent, "run_agent", lambda llm, reg, question: "done")
+
+    runner = CliRunner()
+    index_dir = tmp_path / "indexes"
+    result = runner.invoke(
+        multi_agent.app,
+        ["where?", "--key", "paper", "--index", str(index_dir)],
+    )
+
+    assert result.exit_code == 0
+    assert captured["args"] == ("paper", index_dir)

--- a/tests/unit/test_run_rag_verification.py
+++ b/tests/unit/test_run_rag_verification.py
@@ -80,7 +80,7 @@ def test_build_question_invocation_for_asker_uses_key_and_index(tmp_path: Path) 
 
     assert route == "asker"
     assert "--key" in command
-    assert "--index-dir" in command
+    assert "--index" in command
     assert "--chunks-dir" in command
     assert "--embed-model" in command
 
@@ -110,3 +110,4 @@ def test_build_question_invocation_for_multi_agent_includes_subcommand(tmp_path:
     assert route == "multi"
     assert command[2] == "ask"
     assert "--key" in command
+    assert "--index" in command

--- a/tests/unit/test_tool_rag_tool.py
+++ b/tests/unit/test_tool_rag_tool.py
@@ -1,0 +1,35 @@
+from pathlib import Path
+
+from langchain_core.documents import Document
+
+from src.tool import rag_tool
+
+
+def test_create_rag_tool_respects_custom_index(monkeypatch, tmp_path: Path) -> None:
+    custom_index = tmp_path / "indexes"
+    custom_index.mkdir()
+
+    class DummyRetriever:
+        def get_relevant_documents(self, query: str):
+            return [Document(page_content="answer", metadata={"source": "s"})]
+
+    class DummyFactory:
+        def __init__(self, **kwargs):
+            assert kwargs.get("storage_dir") == custom_index
+
+        def create_vector_retriever(self, config):
+            return DummyRetriever()
+
+        def create_bm25_retriever(self, config):
+            return DummyRetriever()
+
+        def create_hybrid_retriever(self, config):
+            return DummyRetriever()
+
+    monkeypatch.setattr(rag_tool, "RetrieverFactory", DummyFactory)
+
+    tool = rag_tool.create_rag_retrieve_tool("paper", index_dir=custom_index)
+
+    result = tool.run(query="what?", retriever_profile="vector", rerank=False)
+
+    assert result["docs"][0]["text"] == "answer"


### PR DESCRIPTION
## Summary
- add an --index option to the multi-agent CLI and pass custom storage roots into the RAG tool
- let RetrieverFactory accept an optional storage_dir and plumb it through the rag tool helper
- prefer the new flag in the verification harness and document the usage; expand unit coverage for the CLI, harness, and rag tool

## Testing
- pytest tests/unit/test_run_rag_verification.py tests/unit/test_cli_multi_agent.py tests/unit/test_tool_rag_tool.py

------
https://chatgpt.com/codex/tasks/task_e_68d2fbecfff0832caf6b090c13df915d