### PR TITLE
Fix GPU dependency detection in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,17 @@ jobs:
         run: |
           python -m pip install -U pip
           if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
-          if [ $GPU_COUNT -gt 0]; then pip install -r requirements-faiss-gpu.txt; else; pip install -r requirements-faiss-cpu.txt;fi
+          if command -v nvidia-smi >/dev/null 2>&1; then
+            GPU_COUNT=$(nvidia-smi --query-gpu=name --format=csv,noheader | wc -l)
+          else
+            GPU_COUNT=0
+          fi
+
+          if [ "$GPU_COUNT" -gt 0 ]; then
+            pip install -r requirements-faiss-gpu.txt
+          else
+            pip install -r requirements-faiss-cpu.txt
+          fi
           if [ -f requirements-test.txt ]; then pip install -r requirements-test.txt; fi
       - name: Start MCP server
         run: |


### PR DESCRIPTION
## Summary
- define GPU_COUNT using nvidia-smi when available and default to zero otherwise
- fix the shell conditional that selects GPU vs CPU FAISS dependencies in the CI workflow

## Testing
- no tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68d2ff2d46ec832c94cdda45a8ba23dd