### PR TITLE
Fix multi-agent invocation in verification harness

### DIFF
--- a/run_rag_verification.py
+++ b/run_rag_verification.py
@@ -857,7 +857,7 @@ def build_question_invocation(
             if topk_flag:
                 command.extend([topk_flag, str(topk)])
     else:
-        base_args: list[str] = ["ask"]
+        base_args: list[str] = []
         key_flag = determine_flag(multi, ["--key", "-k"]) or "--key"
         if key_flag:
             base_args.extend([key_flag, index_key])

--- a/tests/unit/test_run_rag_verification.py
+++ b/tests/unit/test_run_rag_verification.py
@@ -85,7 +85,9 @@ def test_build_question_invocation_for_asker_uses_key_and_index(tmp_path: Path) 
     assert "--embed-model" in command
 
 
-def test_build_question_invocation_for_multi_agent_includes_subcommand(tmp_path: Path) -> None:
+def test_build_question_invocation_for_multi_agent_omits_legacy_subcommand(
+    tmp_path: Path,
+) -> None:
     asker = Path("src/langchain/lc_ask.py").resolve()
     multi = Path("src/cli/multi_agent.py").resolve()
     question = Question(
@@ -108,5 +110,5 @@ def test_build_question_invocation_for_multi_agent_includes_subcommand(tmp_path:
     )
 
     assert route == "multi"
-    assert command[2] == "ask"
+    assert "ask" not in command
     assert "--key" in command


### PR DESCRIPTION
## Summary
- stop inserting the deprecated `ask` subcommand when shelling out to `multi_agent.py`
- adjust the verification harness unit test to expect the new command layout

## Testing
- `pytest tests/unit/test_run_rag_verification.py`


------
https://chatgpt.com/codex/tasks/task_e_68d3013dfc60832c90ca42550538a8b8