### PR TITLE
fix(lc_ask): require key-derived faiss selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,14 +233,12 @@ make repack-faiss FAISS_DIR=storage/faiss_science__BAAI-bge-small-en-v1.5 OUT=st
 
 **Options:**
 - `--key`: collection key used when building the index (requires matching `--chunks-dir`)
-- `--index`: path to a FAISS index directory (or `index.faiss`) when you want to point directly at a built index
 - `--k`: number of results to return from vector database
 - `--embed-model`: the model index to query (default:`BAAI/bge-small-en-v1.5`)
 - `--ce-model`: cross encoder model (default: `cross-encoder/ms-marco-MiniLM-L-6-v2`)
 - `--chunks-dir`: directory containing the chunk JSONL written by `lc_build_index`
 - `--chunks-file`: explicit path to a chunk JSONL file (skips `--chunks-dir` lookup)
-- `--chunks-dir`: directory containing chunk metadata generated at index build time (default: `<repo>/data_processed`)
-- `--index-dir`: directory containing FAISS index folders (usually the same `--index-dir` passed to `lc_build_index`)
+- `--index-dir`: root directory containing FAISS index folders (the same parent directory passed to `lc_build_index`; defaults to `<repo>/storage`)
 
 
 **Usage**:
@@ -249,8 +247,8 @@ make repack-faiss FAISS_DIR=storage/faiss_science__BAAI-bge-small-en-v1.5 OUT=st
 # Basic query
 python src/langchain/lc_ask.py ask "What is machine learning?"
 
-# Query using an explicit index directory
-python src/langchain/lc_ask.py --index storage/faiss_science__BAAI-bge-small-en-v1.5 --question "Summarise the Higgs boson"
+# Query using a specific key with a custom index directory root
+python src/langchain/lc_ask.py --key science --index-dir /mnt/vector-storage --question "Summarise the Higgs boson"
 
 # Advanced query with options
 python src/langchain/lc_ask.py ask "Explain neural networks" --content-type technical_manual_writer --key science --k 20
@@ -799,7 +797,7 @@ over MCP:
 
 ```bash
 python -m src.cli.multi_agent "Find papers on transformers and call the time tool" \
-  --key default --mcp ./tools/mcp_server.py --index ./storage
+  --key default --mcp ./tools/mcp_server.py --index-dir ./storage
 ```
 
 The command registers the `rag_retrieve` tool for vector search and loads any

--- a/docs/rag-writer.1
+++ b/docs/rag-writer.1
@@ -158,7 +158,6 @@ Start with specific collection:
 [\fB\-\-task\fR \fITASK\fR]
 [\fB\-\-json\fR \fIFILE\fR]
 [\fB\-\-key\fR \fIKEY\fR]
-[\fB\-\-index\fR \fIPATH\fR]
 [\fB\-\-k\fR \fINUM\fR]
 [\fB\-\-chunks-file\fR \fIFILE\fR]
 [\fB\-\-output\fR \fIFILE\fR]
@@ -175,10 +174,7 @@ The task/prompt for the LLM
 JSON file with job specification
 .TP
 .B \-\-key \fIKEY\fR
-Collection key for RAG (default: default). One of \fB--key\fR or \fB--index\fR is required.
-.TP
-.B \-\-index \fIPATH\fR
-Path to a FAISS index directory (or \fIindex.faiss\fR) when addressing an explicit index location.
+Collection key for RAG (default: default). This key must match the embedding model used when building the index.
 .TP
 .B \-\-k \fINUM\fR
 Top-k results for retrieval (default: 30)

--- a/run_rag_verification.py
+++ b/run_rag_verification.py
@@ -839,7 +839,7 @@ def build_question_invocation(
         key_flag = determine_flag(asker, ["--key"]) or "--key"
         if key_flag:
             base_args.extend([key_flag, index_key])
-        index_flag = determine_flag(asker, ["--index", "--index-dir"]) or "--index-dir"
+        index_flag = determine_flag(asker, ["--index-dir", "--index"]) or "--index-dir"
         if index_flag:
             base_args.extend([index_flag, str(index_dir)])
         chunks_flag = determine_flag(asker, ["--chunks-dir"]) or "--chunks-dir"
@@ -861,7 +861,7 @@ def build_question_invocation(
         key_flag = determine_flag(multi, ["--key", "-k"]) or "--key"
         if key_flag:
             base_args.extend([key_flag, index_key])
-        index_flag = determine_flag(multi, ["--index", "--index-dir"]) or "--index"
+        index_flag = determine_flag(multi, ["--index-dir", "--index"]) or "--index-dir"
         if index_flag:
             base_args.extend([index_flag, str(index_dir)])
         command = build_question_command(script, question.prompt, base_args)

--- a/src/cli/multi_agent.py
+++ b/src/cli/multi_agent.py
@@ -28,6 +28,7 @@ def ask(
     ),
     index: Path = typer.Option(
         DEFAULT_INDEX_DIR,
+        "--index-dir",
         "--index",
         help="Directory containing FAISS index directories (default: [repo]/storage)",
     ),

--- a/tests/langchain/test_lc_ask_cli.py
+++ b/tests/langchain/test_lc_ask_cli.py
@@ -197,9 +197,9 @@ def test_lc_ask_supports_question_flag(monkeypatch, tmp_path):
     monkeypatch.setattr(lc_ask.FAISS, "load_local", lambda *args, **kwargs: DummyVectorStore())
     monkeypatch.setattr(lc_ask, "make_retriever", lambda **kwargs: object())
     monkeypatch.setattr(
-        lc_ask.RetrievalQA,
-        "from_chain_type",
-        lambda *args, **kwargs: DummyChain(),
+        lc_ask,
+        "RetrievalQA",
+        SimpleNamespace(from_chain_type=lambda *args, **kwargs: DummyChain()),
     )
     monkeypatch.setattr(lc_ask, "ChatOpenAI", lambda **kwargs: DummyLLM())
 
@@ -261,7 +261,9 @@ def test_lc_ask_accepts_custom_directories(monkeypatch, tmp_path):
 
     def fake_load_chunks(path):
         chunk_call["path"] = Path(path)
-        return [lc_ask.Document("Sample", {})]
+        return [
+            lc_ask.Document(page_content="Sample", metadata={})
+        ]
 
     def fake_load_local(path, *args, **kwargs):
         faiss_call["path"] = Path(path)
@@ -280,9 +282,9 @@ def test_lc_ask_accepts_custom_directories(monkeypatch, tmp_path):
         temperature = 0
 
     monkeypatch.setattr(
-        lc_ask.RetrievalQA,
-        "from_chain_type",
-        lambda *args, **kwargs: DummyChain(),
+        lc_ask,
+        "RetrievalQA",
+        SimpleNamespace(from_chain_type=lambda *args, **kwargs: DummyChain()),
     )
     monkeypatch.setattr(lc_ask, "ChatOpenAI", lambda **kwargs: DummyLLM())
 
@@ -308,82 +310,4 @@ def test_lc_ask_accepts_custom_directories(monkeypatch, tmp_path):
     assert chunk_call["path"] == chunk_file
     assert faiss_call["path"] == faiss_dir
 
-
-def test_lc_ask_accepts_index_path(monkeypatch, tmp_path):
-    _install_dummy_langchain_modules(monkeypatch)
-    lc_ask = importlib.import_module("src.langchain.lc_ask")
-
-    key = "custom/index"
-    question = "What is neuroplasticity?"
-
-    chunks_dir = tmp_path / "chunks"
-    chunks_dir.mkdir()
-    safe_key = "custom-index"
-    chunk_file = chunks_dir / f"lc_chunks_{safe_key}.jsonl"
-    chunk_file.write_text(
-        json.dumps({"text": "Sample", "metadata": {}}) + "\n",
-        encoding="utf-8",
-    )
-
-    index_root = tmp_path / "index"
-    faiss_dir = index_root / f"faiss_{safe_key}__BAAI-bge-small-en-v1.5"
-    faiss_dir.mkdir(parents=True, exist_ok=True)
-    (faiss_dir / "index.faiss").write_text("", encoding="utf-8")
-
-    class DummyEmbeddings:
-        pass
-
-    class DummyVectorStore:
-        pass
-
-    chunk_call = {}
-    faiss_call = {}
-
-    monkeypatch.setattr(lc_ask, "HuggingFaceEmbeddings", lambda model_name: DummyEmbeddings())
-
-    def fake_load_chunks(path):
-        chunk_call["path"] = Path(path)
-        return [lc_ask.Document("Sample", {})]
-
-    def fake_load_local(path, *args, **kwargs):
-        faiss_call["path"] = Path(path)
-        return DummyVectorStore()
-
-    monkeypatch.setattr(lc_ask, "_load_chunks_jsonl", fake_load_chunks)
-    monkeypatch.setattr(lc_ask.FAISS, "load_local", fake_load_local)
-    monkeypatch.setattr(lc_ask, "make_retriever", lambda **kwargs: object())
-
-    class DummyChain:
-        def invoke(self, payload):
-            return {"result": "ok", "source_documents": []}
-
-    class DummyLLM:
-        model_name = "dummy"
-        temperature = 0
-
-    monkeypatch.setattr(
-        lc_ask.RetrievalQA,
-        "from_chain_type",
-        lambda *args, **kwargs: DummyChain(),
-    )
-    monkeypatch.setattr(lc_ask, "ChatOpenAI", lambda **kwargs: DummyLLM())
-    monkeypatch.setenv("TRACE_QID", "test-qid")
-    monkeypatch.setattr(
-        lc_ask.sys,
-        "argv",
-        [
-            "lc_ask.py",
-            "--index",
-            str(faiss_dir),
-            "--question",
-            question,
-            "--chunks-dir",
-            str(chunks_dir),
-        ],
-    )
-
-    lc_ask.main()
-
-    assert chunk_call["path"] == chunk_file
-    assert faiss_call["path"] == faiss_dir
 

--- a/tests/unit/test_cli_multi_agent.py
+++ b/tests/unit/test_cli_multi_agent.py
@@ -82,7 +82,7 @@ def test_cli_passes_custom_index(monkeypatch, tmp_path: Path):
     index_dir = tmp_path / "indexes"
     result = runner.invoke(
         multi_agent.app,
-        ["where?", "--key", "paper", "--index", str(index_dir)],
+        ["where?", "--key", "paper", "--index-dir", str(index_dir)],
     )
 
     assert result.exit_code == 0

--- a/tests/unit/test_run_rag_verification.py
+++ b/tests/unit/test_run_rag_verification.py
@@ -80,7 +80,7 @@ def test_build_question_invocation_for_asker_uses_key_and_index(tmp_path: Path) 
 
     assert route == "asker"
     assert "--key" in command
-    assert "--index" in command
+    assert "--index-dir" in command
     assert "--chunks-dir" in command
     assert "--embed-model" in command
 
@@ -110,4 +110,4 @@ def test_build_question_invocation_for_multi_agent_includes_subcommand(tmp_path:
     assert route == "multi"
     assert command[2] == "ask"
     assert "--key" in command
-    assert "--index" in command
+    assert "--index-dir" in command


### PR DESCRIPTION
## Summary
- remove the lc_ask --faiss-dir flag so indexes are chosen via key + embedding model combinations
- ensure sanitized keys drive chunk discovery and keep the merged-index fallback logic intact
- update CLI documentation and tests to reflect the key requirement and shared index directory semantics

## Testing
- pytest tests/langchain/test_lc_ask_cli.py

------
https://chatgpt.com/codex/tasks/task_e_68d30365c488832ca2dba89eb88c2bc5