### PR TITLE
Ensure index flag detection matches full token

### DIFF
--- a/run_rag_verification.py
+++ b/run_rag_verification.py
@@ -572,6 +572,13 @@ def load_questions(path: Path, *, require_answers: bool) -> list[Question]:
     return questions
 
 
+_FLAG_PATTERN = re.compile(r"(?<![\w-])(-{1,2}[A-Za-z0-9][A-Za-z0-9-]*)(?![\w-])")
+
+
+def _advertised_flags(help_text: str) -> set[str]:
+    return {match.group(1) for match in _FLAG_PATTERN.finditer(help_text)}
+
+
 @lru_cache(maxsize=None)
 def script_help_text(script: Path) -> str:
     try:
@@ -589,8 +596,9 @@ def script_help_text(script: Path) -> str:
 
 def determine_flag(script: Path, candidates: Sequence[str]) -> str | None:
     help_text = script_help_text(script)
+    advertised = _advertised_flags(help_text)
     for flag in candidates:
-        if flag and flag in help_text:
+        if flag and flag in advertised:
             return flag
     return None
 
@@ -601,8 +609,9 @@ def _script_supports_flag(
     """Return the first flag advertised by the script's help output."""
 
     help_text = script_help_text(script)
+    advertised = _advertised_flags(help_text)
     for flag in flag_candidates:
-        if flag and flag in help_text:
+        if flag and flag in advertised:
             return flag
     return None
 

--- a/tests/unit/test_run_rag_verification.py
+++ b/tests/unit/test_run_rag_verification.py
@@ -11,6 +11,7 @@ from run_rag_verification import (
     Question,
     build_builder_command,
     build_question_invocation,
+    determine_flag,
     prepare_pdf_corpus,
 )
 
@@ -113,3 +114,29 @@ def test_build_question_invocation_for_multi_agent_omits_legacy_subcommand(
     assert "ask" not in command
     assert "--key" in command
     assert "--index-dir" in command
+
+
+def test_determine_flag_matches_full_option(tmp_path: Path) -> None:
+    script = tmp_path / "cli.py"
+    script.write_text(
+        """
+import argparse
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--index-dir")
+    parser.add_argument("--chunks-dir")
+    parser.parse_args()
+
+
+if __name__ == "__main__":
+    main()
+""".strip()
+        + "\n",
+        encoding="utf-8",
+    )
+
+    flag = determine_flag(script, ["--index", "--index-dir"])
+
+    assert flag == "--index-dir"


### PR DESCRIPTION
## Summary
- ensure help flag parsing only matches complete option tokens to avoid picking `--index` when only `--index-dir` is advertised
- share the stricter flag detection logic across harness helpers and add coverage for the regression

## Testing
- pytest tests/unit/test_run_rag_verification.py

------
https://chatgpt.com/codex/tasks/task_e_68d30a256f9c832c930b4b44997afe11