### PR TITLE
Support lc_ask index argument and chunk resolution

### DIFF
--- a/tests/langchain/test_lc_ask_cli.py
+++ b/tests/langchain/test_lc_ask_cli.py
@@ -311,3 +311,90 @@ def test_lc_ask_accepts_custom_directories(monkeypatch, tmp_path):
     assert faiss_call["path"] == faiss_dir
 
 
+def test_lc_ask_accepts_explicit_index_directory(monkeypatch, tmp_path):
+    _install_dummy_langchain_modules(monkeypatch)
+    lc_ask = importlib.import_module("src.langchain.lc_ask")
+
+    question = "What is neuroplasticity?"
+    embed_model = "BAAI/bge-small-en-v1.5"
+    embed_safe = "BAAI-bge-small-en-v1.5"
+    safe_key = "papers"
+
+    chunks_dir = tmp_path / "chunks"
+    chunks_dir.mkdir()
+
+    index_dir = tmp_path / "index"
+    faiss_dir = index_dir / f"faiss_{safe_key}__{embed_safe}"
+    faiss_dir.mkdir(parents=True, exist_ok=True)
+    (faiss_dir / "index.faiss").write_text("", encoding="utf-8")
+    chunk_file = faiss_dir / f"lc_chunks_{safe_key}.jsonl"
+    chunk_file.write_text(
+        json.dumps({"text": "Sample", "metadata": {}}) + "\n",
+        encoding="utf-8",
+    )
+
+    class DummyEmbeddings:
+        pass
+
+    class DummyVectorStore:
+        pass
+
+    chunk_call: dict[str, Path] = {}
+    faiss_call: dict[str, Path] = {}
+
+    monkeypatch.setattr(
+        lc_ask,
+        "HuggingFaceEmbeddings",
+        lambda model_name: DummyEmbeddings(),
+    )
+
+    def fake_load_chunks(path):
+        chunk_call["path"] = Path(path)
+        return [lc_ask.Document(page_content="Sample", metadata={})]
+
+    def fake_load_local(path, *args, **kwargs):
+        faiss_call["path"] = Path(path)
+        return DummyVectorStore()
+
+    monkeypatch.setattr(lc_ask, "_load_chunks_jsonl", fake_load_chunks)
+    monkeypatch.setattr(lc_ask.FAISS, "load_local", fake_load_local)
+    monkeypatch.setattr(lc_ask, "make_retriever", lambda **kwargs: object())
+
+    class DummyChain:
+        def invoke(self, payload):
+            return {"result": "ok", "source_documents": []}
+
+    class DummyLLM:
+        model_name = "dummy"
+        temperature = 0
+
+    monkeypatch.setattr(
+        lc_ask,
+        "RetrievalQA",
+        SimpleNamespace(from_chain_type=lambda *args, **kwargs: DummyChain()),
+    )
+    monkeypatch.setattr(lc_ask, "ChatOpenAI", lambda **kwargs: DummyLLM())
+
+    monkeypatch.setenv("TRACE_QID", "test-qid")
+    monkeypatch.setattr(
+        lc_ask.sys,
+        "argv",
+        [
+            "lc_ask.py",
+            "--index",
+            str(faiss_dir),
+            "--question",
+            question,
+            "--chunks-dir",
+            str(chunks_dir),
+            "--embed-model",
+            embed_model,
+        ],
+    )
+
+    lc_ask.main()
+
+    assert chunk_call["path"] == chunk_file
+    assert faiss_call["path"] == faiss_dir
+
+


### PR DESCRIPTION
## Summary
- allow lc_ask to accept either --key or --index by wiring the missing CLI option and key/index resolution helpers
- ensure chunk lookup reuses the inferred key from FAISS directories when only an index path is provided
- add regression coverage so invoking lc_ask with --index locates the colocated chunk file

## Testing
- pytest tests/langchain/test_lc_ask_cli.py
- pytest tests/langchain/test_lc_ask_embedding_validation.py

------
https://chatgpt.com/codex/tasks/task_e_68d30b1a34a4832cb3d965df156b6e53