### PR TITLE
Fix multi-agent harness invocation and docs

### DIFF
--- a/docs/verification.md
+++ b/docs/verification.md
@@ -4,7 +4,9 @@
 the existing CLI scripts (`lc_build_index.py`, `lc_ask.py`, optional
 `multi_agent.py`) against a gold corpus and a set of reference questions. The
 script never imports those tools directly; instead it shells out to the CLIs so
-that the exact same entry points used in production are exercised.
+that the exact same entry points used in production are exercised. Multi-agent
+runs are dispatched via `python -m src.cli.multi_agent ...` so package-relative
+imports resolve consistently for Typer-based entry points.
 
 ## Questions file schema
 

--- a/run_rag_verification.py
+++ b/run_rag_verification.py
@@ -589,8 +589,10 @@ def script_base_command(script: Path) -> list[str]:
 
     return [sys.executable, str(script)]
 
+
 def _advertised_flags(help_text: str) -> set[str]:
     return {match.group(1) for match in _FLAG_PATTERN.finditer(help_text)}
+
 
 @lru_cache(maxsize=None)
 def script_help_text(script: Path) -> str:
@@ -613,10 +615,15 @@ def determine_flag(script: Path, candidates: Sequence[str]) -> str | None:
     try:
         source = script.read_text(encoding="utf-8")
     except (OSError, UnicodeDecodeError):
-        return None
+        source = ""
+
+    for flag in candidates:
+        if flag and flag in advertised:
+            return flag
+
     for flag in candidates:
         if flag and flag in source:
-          return flag
+            return flag
     return None
 
 
@@ -633,6 +640,20 @@ def _script_supports_flag(
     return None
 
 
+def script_supports_subcommand(script: Path, name: str) -> bool:
+    """Return True if the script advertises a Typer-style subcommand."""
+
+    help_text = script_help_text(script)
+    if "Commands:" not in help_text:
+        return False
+    _, commands_section = help_text.split("Commands:", 1)
+    for line in commands_section.splitlines():
+        command_name = line.strip().split(" ", 1)[0] if line.strip() else ""
+        if command_name == name:
+            return True
+    return False
+
+
 def build_question_command(
     script: Path, prompt: str, base_args: List[str]
 ) -> List[str]:
@@ -640,7 +661,6 @@ def build_question_command(
     Build argv for CLIs that may or may not support a --question flag.
     If the script advertises a question flag, use it; otherwise pass the prompt positionally.
     """
-
 
     argv: List[str] = [*script_base_command(script), *base_args]
     flag = _script_supports_flag(script, ["--question", "-q"])
@@ -651,28 +671,6 @@ def build_question_command(
         argv.append(prompt)
     return argv
 
-  
-def build_builder_command(
-    *,
-    builder: Path,
-    index_key: str,
-    pdf_dir: Path,
-    chunks_dir: Path,
-    index_dir: Path,
-) -> list[str]:
-    """Construct the lc_build_index command for the verification run."""
-
-    return [
-        *script_base_command(builder),
-        index_key,
-        "--input-dir",
-        str(pdf_dir),
-        "--chunks-dir",
-        str(chunks_dir),
-        "--index-dir",
-        str(index_dir),
-    ]
-  
 
 def build_builder_command(
     *,
@@ -883,14 +881,13 @@ def build_question_invocation(
     if script is None:
         raise RuntimeError("No asker script available")
     route = "multi" if use_multi else "asker"
-    def _append_flag(script_path: Path, args: list[str], candidates: list[str], value: str) -> None:
+
+    def _append_flag(
+        script_path: Path, args: list[str], candidates: list[str], value: str
+    ) -> None:
         flag = determine_flag(script_path, candidates)
         if not flag:
-            # Typer-based CLIs such as multi_agent.py require running via ``-m`` to
-            # expose subcommand help. When invoked as a script from the harness the
-            # ``--help`` probe used by ``determine_flag`` fails, so fall back to the
-            # primary candidate.
-            flag = candidates[0]
+            return
         args.extend([flag, value])
 
     if not use_multi:
@@ -911,6 +908,9 @@ def build_question_invocation(
                 command.extend([topk_flag, str(topk)])
     else:
         base_args: list[str] = []
+
+        if script_supports_subcommand(multi, "ask"):
+            base_args.append("ask")
 
         _append_flag(multi, base_args, ["--key", "-k"], index_key)
         _append_flag(multi, base_args, ["--index-dir", "--index"], str(index_dir))

--- a/src/research/clients/docs/arxiv_api.md
+++ b/src/research/clients/docs/arxiv_api.md
@@ -1,4 +1,3 @@
-<<<<<<< ours
 # arXiv API Documentation
 
 [See the entire API documentation site here](https://info.arxiv.org/help/api/user-manual.html)
@@ -219,14 +218,12 @@ print_r($response);
 * Use `id_list=cond-mat/0207270` for latest version
 * Use `id_list=cond-mat/0207270v1` for specific version
 
-=======
-# ArXiv API
+## 🧩 Integration Notes
 
-The metadata scanner uses the [ArXiv API](https://arxiv.org/help/api/user-manual) as a fallback
-when a DOI cannot be resolved via Crossref. The API is queried at
-`https://export.arxiv.org/api/query` with the `id_list` parameter set to the
-arXiv identifier extracted from a DOI like `10.48550/arXiv.XXXX`.
+The metadata scanner uses the [arXiv API](https://arxiv.org/help/api/user-manual) as a
+fallback when a DOI cannot be resolved via Crossref. The API is queried at
+`https://export.arxiv.org/api/query` with the `id_list` parameter set to the arXiv
+identifier extracted from a DOI such as `10.48550/arXiv.XXXX`.
 
-The response is an Atom feed. The scanner parses the first entry to obtain
-fields such as title, authors, publication date, and DOI.
->>>>>>> theirs
+Because the response is an Atom feed, the scanner parses the first `<entry>` element to
+obtain fields including title, authors, publication date, and DOI.

--- a/tests/unit/test_run_rag_verification.py
+++ b/tests/unit/test_run_rag_verification.py
@@ -19,7 +19,9 @@ from run_rag_verification import (
 def test_prepare_pdf_corpus_creates_pdfs(tmp_path: Path) -> None:
     markdown_dir = tmp_path / "md"
     markdown_dir.mkdir()
-    (markdown_dir / "sample.md").write_text("hello world\nsecond line", encoding="utf-8")
+    (markdown_dir / "sample.md").write_text(
+        "hello world\nsecond line", encoding="utf-8"
+    )
 
     output_dir = tmp_path / "pdf"
     pdf_paths = prepare_pdf_corpus(markdown_dir, output_dir)
@@ -49,9 +51,6 @@ def test_build_builder_command_targets_pdf_and_chunks(tmp_path: Path) -> None:
         chunks_dir=chunks_dir,
         index_dir=index_dir,
     )
-
-
-    assert command[:2] == [sys.executable, str(builder)]
 
     assert command[0] == sys.executable
     assert command[1:3] == ["-m", "src.langchain.lc_build_index"]
@@ -171,7 +170,7 @@ if __name__ == "__main__":
     for forbidden in ("--key", "--index-dir", "--chunks-dir", "--embed-model"):
         assert forbidden not in command
 
-        
+
 def test_determine_flag_matches_full_option(tmp_path: Path) -> None:
     script = tmp_path / "cli.py"
     script.write_text(
@@ -196,4 +195,3 @@ if __name__ == "__main__":
     flag = determine_flag(script, ["--index", "--index-dir"])
 
     assert flag == "--index-dir"
-


### PR DESCRIPTION
## Summary
- clean up the arXiv API client documentation and add integration notes for the metadata scanner
- update the verification harness so it only forwards CLI flags that exist and detects Typer subcommands when running the multi-agent CLI with `python -m`
- refresh the verification docs and unit tests to cover the updated multi-agent invocation

## Testing
- pytest tests/unit/test_run_rag_verification.py


------
https://chatgpt.com/codex/tasks/task_e_68d360bf17b8832ca79362c600155370