### PR TITLE
Fix multi-agent CLI invocation and clean docs

### DIFF
--- a/src/research/clients/docs/arxiv_api.md
+++ b/src/research/clients/docs/arxiv_api.md
@@ -1,4 +1,3 @@
-<<<<<<< ours
 # arXiv API Documentation
 
 [See the entire API documentation site here](https://info.arxiv.org/help/api/user-manual.html)
@@ -219,14 +218,14 @@ print_r($response);
 * Use `id_list=cond-mat/0207270` for latest version
 * Use `id_list=cond-mat/0207270v1` for specific version
 
-=======
-# ArXiv API
+---
 
-The metadata scanner uses the [ArXiv API](https://arxiv.org/help/api/user-manual) as a fallback
-when a DOI cannot be resolved via Crossref. The API is queried at
-`https://export.arxiv.org/api/query` with the `id_list` parameter set to the
-arXiv identifier extracted from a DOI like `10.48550/arXiv.XXXX`.
+## 🔄 Integration Notes
+
+The metadata scanner uses the [arXiv API](https://arxiv.org/help/api/user-manual)
+as a fallback when a DOI cannot be resolved via Crossref. The API is queried at
+`https://export.arxiv.org/api/query` with the `id_list` parameter set to the arXiv
+identifier extracted from a DOI such as `10.48550/arXiv.XXXX`.
 
 The response is an Atom feed. The scanner parses the first entry to obtain
 fields such as title, authors, publication date, and DOI.
->>>>>>> theirs


### PR DESCRIPTION
## Summary
- resolve the remaining merge artifact in the arXiv API client doc and add an integration note
- update the verification harness flag detection to rely on advertised CLI options so multi-agent runs execute via `python -m`

## Testing
- pytest tests/unit/test_run_rag_verification.py

------
https://chatgpt.com/codex/tasks/task_e_68d359b31a50832c89a9bce9f0cadc2d